### PR TITLE
Add Focus View mode for single-task, image-and-notes workflow

### DIFF
--- a/QA_INVENTORY.md
+++ b/QA_INVENTORY.md
@@ -27,6 +27,7 @@ No URL router — single-page app with in-memory navigation stack.
 | Password Reset | Recovery token | `ResetPasswordScreen.tsx` |
 | Graph View (Canvas) | Default, viewMode='graph' | `CanvasArea.tsx` |
 | List View | viewMode='list'; subtask interaction via graphId-aware store methods | `ListView.tsx` + `workspaceStore.ts` |
+| Focus View | viewMode='focus'; one task at a time with image, notes, status; auto-advances on done | `FocusView.tsx` + `ParallelChooser.tsx` |
 | Execution Mode | executionMode toggle | `CanvasArea.tsx` + `StepDetailPanel.tsx` |
 
 ## Components (23 total)
@@ -63,6 +64,8 @@ No URL router — single-page app with in-memory navigation stack.
 | Component | File | Purpose |
 |-----------|------|---------|
 | ListView | `src/components/ListView/ListView.tsx` | Hierarchical list view with topological sort |
+| FocusView | `src/components/FocusView/FocusView.tsx` | Single-task view: hero image, scrollable notes, status pill that auto-advances on done; transparently drills into containers |
+| ParallelChooser | `src/components/FocusView/ParallelChooser.tsx` | Condensed list shown by FocusView when a completed task unblocks multiple parallel successors |
 | StepDetailPanel | `src/components/ExecutionPanel/StepDetailPanel.tsx` | Execution mode side panel; marks container as done and advances to next task on "Complete Step & Move On" |
 
 ### AI / Generation
@@ -196,7 +199,10 @@ No URL router — single-page app with in-memory navigation stack.
 | Debounced save data loss | workspaceSync.ts | 2s window where crash loses data |
 | Large canvas performance | ReactFlow with many nodes | No virtualization beyond ReactFlow defaults |
 | Touch gesture conflicts | Long-press vs pan vs scroll | 500ms timer may conflict with scroll intent |
-| View mode consistency | graph ↔ list | Changes in one view must reflect in other |
+| View mode consistency | graph ↔ list ↔ focus | Changes in one view must reflect in other |
+| Focus auto-advance timing | `FocusView.tsx` | 450ms delay after status hits 'done'; rapid clicks must not double-cycle |
+| Focus container drill | `logic.ts` `getActionableLeafTasks` | Walks actionable container's child graph; returns leaf tasks only |
+| Focus parallel chooser fallback | `logic.ts` `getNextFocusTasks` | Falls back to global actionable list when direct successors are still blocked |
 | Container deletion UX | ConfirmModal | Deleting container with children is destructive |
 | AI generation errors | gemini.ts | Parse failures, quota limits, network errors |
 | JSON import validation | jsonImport | Partial validation; malformed data could corrupt state |
@@ -211,6 +217,7 @@ No URL router — single-page app with in-memory navigation stack.
 | SaveIndicator driven by sync pipeline | `SaveIndicator.tsx`, `workspaceStore.ts`, `workspaceSync.ts`, `useWorkspaceSync.ts` | Save indicator accuracy, sync error visibility |
 | Typed canvas actions replace DOM events | `workspaceStore.ts`, `CanvasArea.tsx`, `TopBar.tsx`, `ActionNode.tsx`, `StepDetailPanel.tsx` | Delete-selected, fit-view, advance-next |
 | Code splitting / lazy loading | `App.tsx`, `vite.config.ts` | Bundle size, lazy modal loading, chunk splitting |
+| Focus View mode | `workspaceStore.ts`, `logic.ts`, `TopBar.tsx`, `App.tsx`, `FocusView.tsx`, `ParallelChooser.tsx` | Single-task focus mode with image/notes/status, auto-advance, parallel chooser, container drill-in, edit modal |
 
 ## Related Documents
 

--- a/SPATIAL_TASKS_QA_GUIDE.md
+++ b/SPATIAL_TASKS_QA_GUIDE.md
@@ -37,7 +37,8 @@ Spatial Tasks is a **canvas-based task management application** that lets users 
 
 1. **Graph View** (default) — Interactive ReactFlow canvas with nodes, edges, pan/zoom.
 2. **List View** — Hierarchical table with topological sorting and dependency nesting.
-3. **Execution Mode** — Overlay on graph view with a step-detail panel, focusing on one task at a time.
+3. **Focus View** — Single task at a time: hero image (top), scrollable notes (bottom), and a status pill that auto-advances to the next actionable task on completion. Shows a parallel chooser when more than one successor unblocks at once.
+4. **Execution Mode** — Overlay on graph view with a step-detail panel, focusing on one task at a time.
 
 ### Data Flow
 
@@ -333,26 +334,62 @@ User Action → Zustand Store Mutation → localStorage (immediate)
 
 ---
 
-### Flow 14: View Mode Switching (Graph ↔ List)
+### Flow 14: View Mode Switching (Graph ↔ List ↔ Focus)
 
-**What the user is doing**: Toggling between canvas and list views.
+**What the user is doing**: Toggling between canvas, list, and focus views.
 
 **Happy path**:
 1. Click list icon in TopBar → switches to ListView
-2. Changes made in list view reflect in graph view and vice versa
-3. Status changes, node additions all consistent across views
+2. Click crosshair icon in TopBar → switches to FocusView
+3. Changes made in any view reflect in the others
+4. Status changes, node additions all consistent across views
 
 **What could go wrong**:
 - Node created in list view appears at (0,0) on canvas (no position context)
 - Status change in list view doesn't update graph node color
 - List view sorting doesn't match visual graph layout
-- View toggle hidden on small screens — user can't switch back
+- View toggle hidden on small screens — user can't switch back (overflow menu must include all three)
+- Focus view loses its current task when switching away and back (transient state, expected to reset on reload but persist within session)
 
 **Why it matters**: Consistency between views prevents confusion and data issues.
 
 ---
 
-### Flow 15: Mobile Touch Interactions
+### Flow 15: Focus View — Working Through Tasks One-at-a-Time
+
+**What the user is doing**: Picking up an established plan and grinding through tasks with full image + notes context, the way they would on a phone away from the canvas.
+
+**Happy path**:
+1. From an existing project (with tasks containing images and notes), tap the Crosshair icon in TopBar → FocusView opens on the first actionable task
+2. Hero image renders in the top half (or notes fill the screen if no image)
+3. Notes scroll independently if they're long
+4. Tap status pill once → status cycles to In progress
+5. Tap status pill again → status flips to Done; after a brief check-mark animation (~450ms) the next actionable task loads automatically
+6. If the just-completed task unblocks two parallel successors, the ParallelChooser screen appears; tap one to continue
+7. Tap Edit → modal opens with editable Notes textarea + Visual References grid (upload/remove images); Save persists changes
+8. Tap Skip (→) → advance without changing status
+9. Tap Prev (←) → return to the task you just left (in case Done was a misclick)
+10. After completing every task, an "All tasks complete" celebration screen offers Back to list view / node view
+
+**Containers**: Container nodes are never shown directly in focus view — their actionable leaf children are surfaced transparently, with a small breadcrumb (e.g. "Onboarding › Setup auth") above the title.
+
+**Desktop keyboard shortcuts**: Space/Enter = cycle status, → = skip, ← = prev, Esc = exit to list view.
+
+**What could go wrong**:
+- Auto-advance fires too fast and the user can't visually confirm completion
+- Skip/Prev buttons disabled when they shouldn't be (or enabled when no targets exist)
+- ParallelChooser doesn't appear when expected (e.g. the next task is still blocked by another predecessor)
+- Image carousel pagination dots / swipe broken on multi-image tasks
+- Edit modal doesn't save changes back to the node
+- Status pill doesn't visually reflect the in_progress / done states across cycles
+- "All tasks complete" screen shown even when there are still unblocked tasks elsewhere in the project (regression in `getActionableLeafTasks`)
+- View toggle missing from mobile overflow menu
+
+**Why it matters**: Focus view is the intended on-the-go consumption surface. Notes and images are useless if buried; getting this flow smooth is what makes the app worth carrying around.
+
+---
+
+### Flow 16: Mobile Touch Interactions
 
 **What the user is doing**: Using the app on a phone or tablet.
 
@@ -489,6 +526,15 @@ User Action → Zustand Store Mutation → localStorage (immediate)
 | QA-B032a | Execution mode | Complete container substeps and advance to next task | Execution mode active; inside a container node with substeps; sibling nodes exist after the container in parent graph | 1. Complete all substeps inside a container (or click "Complete Step & Move On"). 2. Observe navigation back to parent graph. | The container node is marked as done in the parent graph. The canvas automatically pans to the next actionable sibling node. The next node is highlighted. No grey/blank screen. | Container status correctly set to 'done'; downstream nodes become unblocked; advance-next finds correct successor | P0 |
 | QA-B033 | Performance | Pan and zoom with 100+ nodes | Graph loaded with 100+ nodes and many edges | 1. Pan the canvas. 2. Zoom in and out. 3. Toggle fit-view. | Interactions remain responsive (no visible frame drops or lag). Fit-view completes within a reasonable time. | Framerate during pan/zoom; ReactFlow virtualization working; MiniMap stays responsive | P1 |
 | QA-B034 | Performance | Deep nesting navigation speed | Graph with 5+ levels of nested ContainerNodes | 1. Navigate down through 5 levels of nesting. 2. Use breadcrumb to jump back to root. 3. Navigate down again. | Each navigation completes quickly. No noticeable delay on enter or back. Breadcrumbs remain correct at every level. | Memory leaks from repeated navigation; viewport restore speed; breadcrumb truncation at deep levels | P2 |
+| QA-B035 | Focus view | Enter Focus View shows next actionable task | Project with several action nodes; first one has both notes and images | 1. Click the Crosshair icon in TopBar to switch to Focus View. | View renders the first actionable leaf task. If it has images, hero image fills top half (~40-45vh); otherwise notes fill the screen. Title and notes are shown below. Status pill is visible at the bottom. Header shows "Task 1 of N". | Should match `getActionableLeafTasks(activeGraph, graphs)[0]`; "No image for this task" pill shown when images array empty | P0 |
+| QA-B036 | Focus view | Status pill cycles and auto-advances on done | Focus View showing a task with status='todo' | 1. Tap the status pill once. 2. Tap it again. 3. Wait. | First tap cycles to 'in_progress' (blue). Second tap cycles to 'done' and shows a green check confirmation; after ~450ms the next actionable task replaces the current one. | Rapid clicks must not skip past 'in_progress'; advance is debounced via `advancing` flag; check that status updates also reflect in graph and list views | P0 |
+| QA-B037 | Focus view | Parallel chooser appears when 2+ successors unblock | Graph where node A has two outgoing edges to B and C, both with no other dependencies | 1. Open Focus View on node A. 2. Mark A done via the status pill. 3. After auto-advance delay, observe the screen. | The ParallelChooser screen renders, listing B and C with a small thumbnail (or placeholder), title, optional notes snippet. Tapping one continues focus on that task. | Rows should be ≥64px tall (touch target); cancel button returns to A's view if user changes mind; if a successor is still blocked by another predecessor it must NOT appear | P0 |
+| QA-B038 | Focus view | Container nodes are auto-drilled, never shown | Project root contains only a container with leaf tasks inside | 1. Switch to Focus View at root level. | The view shows a leaf task from inside the container, with a small breadcrumb above the title (e.g. "Container Title"). Container itself is never the focus task. | If container has nested containers, breadcrumb chains them ("Outer › Inner"); fully completed containers are skipped; ParallelChooser also flattens containers when collecting successors | P1 |
+| QA-B039 | Focus view | Edit modal updates notes and images | Focus View on any task | 1. Tap the Edit (pencil) button. 2. In the modal, change the notes text and add an image. 3. Tap Save. | Modal closes; the focus view immediately reflects the new notes and image hero. Switching to graph or list view confirms the change persisted. | ImagesEditor inside modal supports add/remove with 5 MB cap; closing modal via X discards unsaved edits | P1 |
+| QA-B040 | Focus view | Skip and Prev navigation | Focus View with at least 3 actionable tasks remaining | 1. Tap Skip (→). 2. Tap Skip again. 3. Tap Prev (←). | Skip moves to the next actionable task without changing status; Prev returns to the immediately previous focus task (in-memory history). At the start of a session Prev is disabled. | Skip is disabled when only one actionable task remains; status of skipped tasks remains unchanged | P1 |
+| QA-B041 | Focus view | All-tasks-complete celebration screen | Project with a small, fully connected workflow | 1. From Focus View, complete every task in sequence. | After the last task is marked done, instead of another task the celebration screen appears: party-popper icon, "All tasks complete", and buttons to return to list view or node view. | Should not appear if there are still actionable tasks in unrelated branches; "Back to list view" / "Back to node view" buttons must work | P1 |
+| QA-B042 | Focus view | View toggle hidden but reachable on small screens | Mobile/small viewport (< sm breakpoint) | 1. Open the TopBar overflow menu (kebab/MoreVertical icon). | The overflow menu lists Node View, List View, AND Focus View options, each with the active state highlighted when current. | Tapping switches view mode and closes the menu; new Focus button must not be left out of mobile UX | P0 |
+| QA-B043 | Focus view | Desktop keyboard shortcuts | Focus View on desktop with one task showing | 1. Press Space. 2. Press Space again. 3. Press → key. 4. Press ← key. 5. Press Esc. | Space/Enter cycles status (and may auto-advance); → triggers Skip; ← triggers Prev; Esc switches viewMode back to 'list'. | Shortcuts must NOT fire while typing in the Edit modal's textarea; should be inert on touch devices | P2 |
 
 ### Group C: Projects, Persistence & AI (21 cases)
 
@@ -629,9 +675,10 @@ User Action → Zustand Store Mutation → localStorage (immediate)
 - [ ] No data loss when closing tab during debounce window (verify beforeunload warning)
 
 ### Views & Modes
-- [ ] Graph ↔ List view toggle works
-- [ ] Status changes in list view reflect in graph view (and vice versa)
+- [ ] Graph ↔ List ↔ Focus view toggle works
+- [ ] Status changes in any view reflect in the others
 - [ ] Tasks created in list view appear in graph view
+- [ ] Focus View opens on the first actionable task; auto-advances on done; ParallelChooser appears for multi-successor unblocks; container leaves are surfaced transparently
 - [ ] Execution mode activates with correct panel and highlighting
 - [ ] "Next" button in execution mode navigates to correct actionable node
 - [ ] Blocked/actionable states are accurate based on dependencies

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Sidebar } from './components/Layout/Sidebar';
 import { TopBar } from './components/Layout/TopBar';
 import { CanvasArea } from './components/Canvas/CanvasArea';
 import { ListView } from './components/ListView/ListView';
+import { FocusView } from './components/FocusView/FocusView';
 import { ToastContainer } from './components/UI/Toast';
 import { LoadingScreen } from './components/UI/LoadingScreen';
 import { useWorkspaceStore } from './store/workspaceStore';
@@ -41,7 +42,11 @@ function App() {
             <Sidebar onGenerateFlow={() => setShowFlowGenerator(true)} onImportPlan={() => setShowMarkdownImporter(true)} />
             <div className="flex-1 flex flex-col h-full overflow-hidden relative">
                 <TopBar />
-                {viewMode === 'list' ? <ListView /> : <CanvasArea onGenerateFlow={() => setShowFlowGenerator(true)} />}
+                {viewMode === 'list'
+                    ? <ListView />
+                    : viewMode === 'focus'
+                        ? <FocusView />
+                        : <CanvasArea onGenerateFlow={() => setShowFlowGenerator(true)} />}
             </div>
             <ToastContainer />
             <Suspense fallback={null}>

--- a/src/components/FocusView/FocusView.tsx
+++ b/src/components/FocusView/FocusView.tsx
@@ -1,0 +1,609 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    Crosshair, ChevronLeft, ChevronRight, Check, Circle, Clock, CheckCircle2,
+    Pencil, SkipForward, X, ImageOff, PartyPopper,
+} from 'lucide-react';
+import { clsx } from 'clsx';
+import { useWorkspaceStore } from '../../store/workspaceStore';
+import { Node, ImageAttachment } from '../../types';
+import { getActionableLeafTasks, getNextFocusTasks, FocusTaskRef } from '../../utils/logic';
+import { ImageLightbox } from '../Nodes/ImageLightbox';
+import { ImagesEditor } from '../Nodes/ImagesEditor';
+import { useDeviceDetect } from '../../hooks/useDeviceDetect';
+import { useKeyboardOffset } from '../../hooks/useKeyboardOffset';
+import { ParallelChooser } from './ParallelChooser';
+
+const STATUS_LABEL: Record<string, string> = {
+    todo: 'To do',
+    in_progress: 'In progress',
+    done: 'Done',
+};
+
+const ADVANCE_DELAY_MS = 450;
+
+const StatusGlyph = ({ status }: { status?: string }) => {
+    if (status === 'done') return <CheckCircle2 className="w-5 h-5" />;
+    if (status === 'in_progress') return <Clock className="w-5 h-5" />;
+    return <Circle className="w-5 h-5" />;
+};
+
+/** Linkify URLs in plain-text notes — mirrors NotesEditor URL-detection semantics. */
+const renderNotesWithLinks = (notes: string) => {
+    const urlRegex = /(https?:\/\/[^\s)]+)/gi;
+    const parts: Array<string | { url: string }> = [];
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = urlRegex.exec(notes)) !== null) {
+        if (match.index > lastIndex) parts.push(notes.slice(lastIndex, match.index));
+        parts.push({ url: match[0] });
+        lastIndex = match.index + match[0].length;
+    }
+    if (lastIndex < notes.length) parts.push(notes.slice(lastIndex));
+    return parts.map((part, i) => {
+        if (typeof part === 'string') {
+            return <span key={i}>{part}</span>;
+        }
+        return (
+            <a
+                key={i}
+                href={part.url}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-sky-300 underline hover:text-sky-200 break-all"
+            >
+                {part.url}
+            </a>
+        );
+    });
+};
+
+/** Hero image carousel — swipe / arrow through multiple images, tap to open lightbox. */
+const ImageHero = ({ images }: { images: ImageAttachment[] }) => {
+    const [index, setIndex] = useState(0);
+    const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+    const touchStartX = useRef<number | null>(null);
+
+    // Reset to first image when the underlying images change (e.g. task switch).
+    useEffect(() => {
+        setIndex(0);
+    }, [images]);
+
+    const hasMany = images.length > 1;
+    const safeIndex = Math.min(index, images.length - 1);
+    const current = images[safeIndex];
+
+    const goPrev = useCallback(() => {
+        if (!hasMany) return;
+        setIndex(i => (i - 1 + images.length) % images.length);
+    }, [hasMany, images.length]);
+
+    const goNext = useCallback(() => {
+        if (!hasMany) return;
+        setIndex(i => (i + 1) % images.length);
+    }, [hasMany, images.length]);
+
+    const onTouchStart = (e: React.TouchEvent) => {
+        touchStartX.current = e.touches[0].clientX;
+    };
+    const onTouchEnd = (e: React.TouchEvent) => {
+        if (touchStartX.current === null) return;
+        const dx = e.changedTouches[0].clientX - touchStartX.current;
+        touchStartX.current = null;
+        if (Math.abs(dx) < 40) return;
+        if (dx > 0) goPrev();
+        else goNext();
+    };
+
+    if (!current) return null;
+
+    return (
+        <>
+            <div
+                className="relative w-full h-full bg-slate-950 flex items-center justify-center select-none"
+                onTouchStart={onTouchStart}
+                onTouchEnd={onTouchEnd}
+            >
+                <button
+                    onClick={() => setLightboxIndex(safeIndex)}
+                    className="block w-full h-full"
+                    title="Tap to view full size"
+                >
+                    <img
+                        src={current.dataUrl}
+                        alt={current.name ?? `Image ${safeIndex + 1}`}
+                        className="w-full h-full object-contain"
+                    />
+                </button>
+
+                {hasMany && (
+                    <>
+                        <button
+                            onClick={(e) => { e.stopPropagation(); goPrev(); }}
+                            className="absolute left-2 top-1/2 -translate-y-1/2 p-2 rounded-full bg-slate-900/70 text-slate-200 hover:bg-slate-800 hover:text-white min-h-[40px] min-w-[40px] flex items-center justify-center"
+                            title="Previous image"
+                            aria-label="Previous image"
+                        >
+                            <ChevronLeft className="w-5 h-5" />
+                        </button>
+                        <button
+                            onClick={(e) => { e.stopPropagation(); goNext(); }}
+                            className="absolute right-2 top-1/2 -translate-y-1/2 p-2 rounded-full bg-slate-900/70 text-slate-200 hover:bg-slate-800 hover:text-white min-h-[40px] min-w-[40px] flex items-center justify-center"
+                            title="Next image"
+                            aria-label="Next image"
+                        >
+                            <ChevronRight className="w-5 h-5" />
+                        </button>
+                        <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex items-center gap-1.5">
+                            {images.map((_, i) => (
+                                <span
+                                    key={i}
+                                    className={clsx(
+                                        'h-1.5 rounded-full transition-all',
+                                        i === safeIndex ? 'w-4 bg-white' : 'w-1.5 bg-white/40'
+                                    )}
+                                />
+                            ))}
+                        </div>
+                    </>
+                )}
+            </div>
+
+            {lightboxIndex !== null && (
+                <ImageLightbox
+                    images={images}
+                    index={lightboxIndex}
+                    onIndexChange={setLightboxIndex}
+                    onClose={() => setLightboxIndex(null)}
+                />
+            )}
+        </>
+    );
+};
+
+interface EditModalProps {
+    node: Node;
+    graphId: string;
+    onClose: () => void;
+}
+
+/** Combined notes + images edit modal — opens from the focus view "Edit" button. */
+const EditModal = ({ node, graphId, onClose }: EditModalProps) => {
+    const updateNode = useWorkspaceStore(state => state.updateNode);
+    const keyboardOffset = useKeyboardOffset();
+    const [notes, setNotes] = useState(node.meta?.notes ?? '');
+    const [images, setImages] = useState<ImageAttachment[]>(node.meta?.images ?? []);
+
+    const handleSave = useCallback(() => {
+        updateNode(node.id, {
+            meta: { ...(node.meta ?? {}), notes, images },
+        }, graphId);
+        onClose();
+    }, [updateNode, node.id, node.meta, notes, images, graphId, onClose]);
+
+    return (
+        <div
+            className="fixed inset-0 z-[100] flex items-end sm:items-center justify-center"
+            onClick={onClose}
+        >
+            <div className="absolute inset-0 bg-black/70" />
+            <div
+                className="relative w-full sm:max-w-lg sm:rounded-xl rounded-t-2xl shadow-2xl border border-slate-700 bg-slate-900 p-4 max-h-[90vh] flex flex-col"
+                style={{ marginBottom: keyboardOffset }}
+                onClick={e => e.stopPropagation()}
+            >
+                <div className="flex items-center justify-between mb-3 flex-shrink-0">
+                    <span className="text-sm font-semibold text-slate-200">Edit Task</span>
+                    <button
+                        onClick={onClose}
+                        className="p-1.5 rounded text-slate-400 hover:bg-slate-700 hover:text-white min-h-[36px] min-w-[36px] flex items-center justify-center"
+                        aria-label="Close edit dialog"
+                    >
+                        <X className="w-4 h-4" />
+                    </button>
+                </div>
+
+                <div className="overflow-y-auto flex-1 space-y-3">
+                    <div>
+                        <label className="block text-[11px] font-medium uppercase tracking-wide text-slate-400 mb-1">
+                            Notes
+                        </label>
+                        <textarea
+                            value={notes}
+                            onChange={e => setNotes(e.target.value)}
+                            placeholder="Add notes…"
+                            rows={6}
+                            className="w-full bg-transparent border border-slate-700 rounded text-sm resize-y outline-none p-3 text-slate-200 placeholder-slate-600 focus:border-slate-500"
+                            onKeyDown={e => {
+                                if (e.key === 'Escape') onClose();
+                                e.stopPropagation();
+                            }}
+                        />
+                    </div>
+
+                    <ImagesEditor
+                        images={images}
+                        onChange={setImages}
+                        onClose={() => { /* close handled by modal X */ }}
+                        canEdit
+                    />
+                </div>
+
+                <button
+                    onClick={handleSave}
+                    className="mt-3 w-full text-sm font-medium py-2.5 rounded-lg bg-purple-600 hover:bg-purple-500 text-white flex-shrink-0"
+                >
+                    Save
+                </button>
+            </div>
+        </div>
+    );
+};
+
+/**
+ * Single-task focus view. Reads the active graph, finds the next actionable
+ * leaf task (drilling into containers), and presents image + notes + status
+ * controls. Marking a task done auto-advances; multiple successors trigger
+ * the parallel chooser.
+ */
+export const FocusView: React.FC = () => {
+    const { isTouchDevice } = useDeviceDetect();
+    const activeGraphId = useWorkspaceStore(state => state.activeGraphId);
+    const graphs = useWorkspaceStore(state => state.graphs);
+    const focusNodeId = useWorkspaceStore(state => state.focusNodeId);
+    const focusContextGraphId = useWorkspaceStore(state => state.focusContextGraphId);
+    const setFocusTask = useWorkspaceStore(state => state.setFocusTask);
+    const clearFocusTask = useWorkspaceStore(state => state.clearFocusTask);
+    const cycleNodeStatus = useWorkspaceStore(state => state.cycleNodeStatus);
+    const setViewMode = useWorkspaceStore(state => state.setViewMode);
+
+    const activeGraph = activeGraphId ? graphs[activeGraphId] : null;
+
+    // Pre-compute the actionable session in the current project scope.
+    // Containers are flattened — only leaf action tasks are returned.
+    const allActionable = useMemo<FocusTaskRef[]>(() => {
+        if (!activeGraph) return [];
+        return getActionableLeafTasks(activeGraph, graphs);
+    }, [activeGraph, graphs]);
+
+    // Total leaf-task count for the progress indicator (done + actionable + still-blocked).
+    const totalLeafCount = useMemo(() => {
+        if (!activeGraph) return 0;
+        let count = 0;
+        const walk = (graphId: string) => {
+            const g = graphs[graphId];
+            if (!g) return;
+            for (const n of g.nodes) {
+                if (n.type === 'action') count++;
+                else if (n.type === 'container' && n.childGraphId) walk(n.childGraphId);
+            }
+        };
+        walk(activeGraph.id);
+        return count;
+    }, [activeGraph, graphs]);
+
+    const doneLeafCount = useMemo(() => {
+        if (!activeGraph) return 0;
+        let count = 0;
+        const walk = (graphId: string) => {
+            const g = graphs[graphId];
+            if (!g) return;
+            for (const n of g.nodes) {
+                if (n.type === 'action' && n.status === 'done') count++;
+                else if (n.type === 'container' && n.childGraphId) walk(n.childGraphId);
+            }
+        };
+        walk(activeGraph.id);
+        return count;
+    }, [activeGraph, graphs]);
+
+    // Local UI state
+    const [parallelOptions, setParallelOptions] = useState<FocusTaskRef[] | null>(null);
+    const [editing, setEditing] = useState(false);
+    const [advancing, setAdvancing] = useState(false);
+    const [history, setHistory] = useState<Array<{ nodeId: string; graphId: string }>>([]);
+    const advanceTimerRef = useRef<number | null>(null);
+
+    // Resolve the current focus task object — defensively, in case the underlying graph changed.
+    const currentTask = useMemo<FocusTaskRef | null>(() => {
+        if (!focusNodeId || !focusContextGraphId) return null;
+        const g = graphs[focusContextGraphId];
+        if (!g) return null;
+        const node = g.nodes.find(n => n.id === focusNodeId);
+        if (!node) return null;
+        // Reconstruct breadcrumb for display by finding a matching entry in the actionable list.
+        const match = allActionable.find(t => t.node.id === node.id && t.graphId === g.id);
+        return match ?? { node, graphId: g.id, breadcrumb: [] };
+    }, [focusNodeId, focusContextGraphId, graphs, allActionable]);
+
+    // Pick the first actionable task on mount (or when graph context changes
+    // and the previous focus is no longer valid / actionable).
+    useEffect(() => {
+        if (parallelOptions) return; // chooser visible — don't auto-pick
+        if (currentTask) return;     // already have a valid focus task
+        const first = allActionable[0];
+        if (first) {
+            setFocusTask(first.node.id, first.graphId);
+        }
+    }, [currentTask, allActionable, setFocusTask, parallelOptions]);
+
+    // Cleanup any pending advance timer on unmount or task change.
+    useEffect(() => {
+        return () => {
+            if (advanceTimerRef.current !== null) {
+                window.clearTimeout(advanceTimerRef.current);
+            }
+        };
+    }, []);
+
+    const advanceTo = useCallback((next: FocusTaskRef) => {
+        if (currentTask) {
+            setHistory(h => [...h, { nodeId: currentTask.node.id, graphId: currentTask.graphId }]);
+        }
+        setFocusTask(next.node.id, next.graphId);
+        setAdvancing(false);
+    }, [currentTask, setFocusTask]);
+
+    const handleStatusClick = useCallback(() => {
+        if (!currentTask || advancing) return;
+        const isDone = currentTask.node.status === 'done';
+        cycleNodeStatus(currentTask.node.id, currentTask.graphId);
+        if (isDone) return; // cycling done → todo, no advance
+
+        const willBeDone = currentTask.node.status === 'in_progress';
+        if (!willBeDone) return; // still going through todo → in_progress
+
+        // We just completed the task — schedule auto-advance.
+        setAdvancing(true);
+        if (advanceTimerRef.current !== null) {
+            window.clearTimeout(advanceTimerRef.current);
+        }
+        advanceTimerRef.current = window.setTimeout(() => {
+            // Re-read fresh state at the moment of advancement.
+            const freshState = useWorkspaceStore.getState();
+            const freshActive = freshState.activeGraphId ? freshState.graphs[freshState.activeGraphId] : null;
+            if (!freshActive) {
+                setAdvancing(false);
+                return;
+            }
+            const nextTasks = getNextFocusTasks(
+                currentTask.node.id,
+                currentTask.graphId,
+                freshActive,
+                freshState.graphs,
+            );
+            if (nextTasks.length === 0) {
+                clearFocusTask();
+                setAdvancing(false);
+            } else if (nextTasks.length === 1) {
+                advanceTo(nextTasks[0]);
+            } else {
+                setParallelOptions(nextTasks);
+                setAdvancing(false);
+            }
+        }, ADVANCE_DELAY_MS);
+    }, [currentTask, advancing, cycleNodeStatus, advanceTo, clearFocusTask]);
+
+    const handleSkip = useCallback(() => {
+        if (!currentTask) return;
+        const next = allActionable.find(t => t.node.id !== currentTask.node.id);
+        if (next) advanceTo(next);
+    }, [currentTask, allActionable, advanceTo]);
+
+    const handlePrev = useCallback(() => {
+        if (history.length === 0) return;
+        const last = history[history.length - 1];
+        setHistory(h => h.slice(0, -1));
+        setFocusTask(last.nodeId, last.graphId);
+        setParallelOptions(null);
+    }, [history, setFocusTask]);
+
+    const handleChooseParallel = useCallback((task: FocusTaskRef) => {
+        setParallelOptions(null);
+        advanceTo(task);
+    }, [advanceTo]);
+
+    // Desktop keyboard shortcuts (mirrors common reading/queue UX).
+    useEffect(() => {
+        if (isTouchDevice) return;
+        if (editing || parallelOptions) return;
+        const handler = (e: KeyboardEvent) => {
+            if (e.target instanceof HTMLElement) {
+                const tag = e.target.tagName;
+                if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+            }
+            if (e.key === ' ' || e.key === 'Enter') {
+                e.preventDefault();
+                handleStatusClick();
+            } else if (e.key === 'ArrowRight') {
+                handleSkip();
+            } else if (e.key === 'ArrowLeft') {
+                handlePrev();
+            } else if (e.key === 'Escape') {
+                setViewMode('list');
+            }
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [isTouchDevice, editing, parallelOptions, handleStatusClick, handleSkip, handlePrev, setViewMode]);
+
+    // ---------- RENDER ----------
+    if (!activeGraph) {
+        return (
+            <div className="flex-1 h-full bg-gray-950 flex items-center justify-center text-gray-500">
+                No graph selected
+            </div>
+        );
+    }
+
+    if (parallelOptions) {
+        return (
+            <ParallelChooser
+                options={parallelOptions}
+                onSelect={handleChooseParallel}
+                onCancel={() => setParallelOptions(null)}
+            />
+        );
+    }
+
+    if (!currentTask) {
+        // No actionable tasks left — celebrate and offer a way out.
+        return (
+            <div className="flex-1 h-full bg-gray-950 flex items-center justify-center px-6">
+                <div className="text-center max-w-sm">
+                    <PartyPopper className="w-12 h-12 text-purple-400 mx-auto mb-4" />
+                    <h2 className="text-xl font-semibold text-white mb-2">All tasks complete</h2>
+                    <p className="text-sm text-gray-400 mb-6">
+                        {totalLeafCount > 0
+                            ? `You finished all ${totalLeafCount} task${totalLeafCount === 1 ? '' : 's'} in this view.`
+                            : 'There are no tasks here yet.'}
+                    </p>
+                    <div className="flex flex-col gap-2">
+                        <button
+                            onClick={() => setViewMode('list')}
+                            className="px-4 py-2.5 rounded-lg bg-purple-600 hover:bg-purple-500 text-white text-sm font-medium"
+                        >
+                            Back to list view
+                        </button>
+                        <button
+                            onClick={() => setViewMode('graph')}
+                            className="px-4 py-2.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-200 text-sm"
+                        >
+                            Back to node view
+                        </button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    const node = currentTask.node;
+    const images = node.meta?.images ?? [];
+    const notes = node.meta?.notes ?? '';
+    const hasImages = images.length > 0;
+    const hasNotes = notes.trim().length > 0;
+    const sessionIndex = doneLeafCount + 1;
+
+    return (
+        <div className="flex-1 h-full bg-gray-950 flex flex-col overflow-hidden">
+            {/* Header: progress, breadcrumb, prev */}
+            <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800 flex-shrink-0 bg-gray-950">
+                <div className="flex items-center gap-2 min-w-0">
+                    <Crosshair className="w-4 h-4 text-purple-400 flex-shrink-0" />
+                    <span className="text-xs text-gray-400 flex-shrink-0">
+                        Task {Math.min(sessionIndex, totalLeafCount)} of {totalLeafCount}
+                    </span>
+                    {currentTask.breadcrumb.length > 0 && (
+                        <span className="text-xs text-gray-500 truncate hidden sm:inline">
+                            · {currentTask.breadcrumb.join(' › ')}
+                        </span>
+                    )}
+                </div>
+                <div className="flex items-center gap-1">
+                    <button
+                        onClick={handlePrev}
+                        disabled={history.length === 0}
+                        className="p-2 rounded text-gray-400 hover:text-white hover:bg-gray-800 disabled:opacity-30 disabled:cursor-not-allowed touch:min-h-[40px] touch:min-w-[40px] flex items-center justify-center"
+                        title="Previous task (←)"
+                        aria-label="Previous task"
+                    >
+                        <ChevronLeft className="w-4 h-4" />
+                    </button>
+                </div>
+            </div>
+
+            {/* Image hero (top half) — only when images exist */}
+            {hasImages && (
+                <div className="flex-shrink-0 h-[40vh] sm:h-[45vh] bg-slate-950 border-b border-gray-800">
+                    <ImageHero images={images} />
+                </div>
+            )}
+
+            {/* Title + notes (bottom, scrolls) */}
+            <div className="flex-1 overflow-y-auto px-4 sm:px-6 py-4">
+                <div className="max-w-2xl mx-auto">
+                    <h1 className={clsx(
+                        'text-xl sm:text-2xl font-semibold text-white mb-3 transition-opacity',
+                        node.status === 'done' && 'opacity-60',
+                    )}>
+                        {node.title}
+                    </h1>
+
+                    {!hasImages && (
+                        <div className="mb-4 inline-flex items-center gap-1.5 text-[11px] text-gray-500 bg-gray-900/60 border border-gray-800 rounded-full px-2.5 py-1">
+                            <ImageOff className="w-3 h-3" />
+                            No image for this task
+                        </div>
+                    )}
+
+                    {hasNotes ? (
+                        <div className="text-sm sm:text-base text-slate-200 whitespace-pre-wrap leading-relaxed">
+                            {renderNotesWithLinks(notes)}
+                        </div>
+                    ) : (
+                        <p className="text-sm text-gray-500 italic">No notes for this task. Tap Edit to add some.</p>
+                    )}
+                </div>
+            </div>
+
+            {/* Action bar */}
+            <div
+                className="flex-shrink-0 border-t border-gray-800 bg-gray-950 px-4 py-3"
+                style={{ paddingBottom: 'calc(0.75rem + var(--sab, 0px))' }}
+            >
+                <div className="max-w-2xl mx-auto flex items-center gap-2">
+                    <button
+                        onClick={handleStatusClick}
+                        disabled={advancing}
+                        className={clsx(
+                            'flex-1 flex items-center justify-center gap-2 py-3 rounded-lg font-medium transition-all touch:min-h-[52px]',
+                            advancing
+                                ? 'bg-green-600 text-white scale-[0.98]'
+                                : node.status === 'done'
+                                    ? 'bg-green-600/90 hover:bg-green-600 text-white'
+                                    : node.status === 'in_progress'
+                                        ? 'bg-blue-600 hover:bg-blue-500 text-white'
+                                        : 'bg-slate-700 hover:bg-slate-600 text-slate-100',
+                        )}
+                        title={`Status: ${STATUS_LABEL[node.status ?? 'todo']} — tap to advance`}
+                    >
+                        {advancing ? <Check className="w-5 h-5" /> : <StatusGlyph status={node.status} />}
+                        <span className="text-sm">
+                            {advancing
+                                ? 'Done!'
+                                : node.status === 'done'
+                                    ? 'Done · tap to reopen'
+                                    : node.status === 'in_progress'
+                                        ? 'Mark complete'
+                                        : 'Start task'}
+                        </span>
+                    </button>
+                    <button
+                        onClick={() => setEditing(true)}
+                        className="px-3 py-3 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-200 touch:min-h-[52px] touch:min-w-[52px] flex items-center justify-center"
+                        title="Edit notes & images"
+                        aria-label="Edit notes and images"
+                    >
+                        <Pencil className="w-4 h-4" />
+                    </button>
+                    <button
+                        onClick={handleSkip}
+                        disabled={allActionable.length <= 1}
+                        className="px-3 py-3 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-200 disabled:opacity-30 disabled:cursor-not-allowed touch:min-h-[52px] touch:min-w-[52px] flex items-center justify-center"
+                        title="Skip to next task (→)"
+                        aria-label="Skip to next task"
+                    >
+                        <SkipForward className="w-4 h-4" />
+                    </button>
+                </div>
+            </div>
+
+            {editing && (
+                <EditModal
+                    node={node}
+                    graphId={currentTask.graphId}
+                    onClose={() => setEditing(false)}
+                />
+            )}
+        </div>
+    );
+};

--- a/src/components/FocusView/ParallelChooser.tsx
+++ b/src/components/FocusView/ParallelChooser.tsx
@@ -1,0 +1,77 @@
+import { GitBranch, ChevronRight, ImageOff } from 'lucide-react';
+import { FocusTaskRef } from '../../utils/logic';
+
+interface ParallelChooserProps {
+    options: FocusTaskRef[];
+    onSelect: (task: FocusTaskRef) => void;
+    onCancel: () => void;
+}
+
+/**
+ * Condensed list of next-actionable tasks, shown when completing a task
+ * unblocks more than one parallel option. Mirrors the visual language of
+ * ListView so users feel at home, but each row is tappable to advance.
+ */
+export const ParallelChooser: React.FC<ParallelChooserProps> = ({ options, onSelect, onCancel }) => {
+    return (
+        <div className="flex-1 h-full bg-gray-950 overflow-y-auto">
+            <div className="max-w-md mx-auto px-4 py-6 space-y-3">
+                <div className="flex items-center gap-2 text-purple-300 mb-1">
+                    <GitBranch className="w-4 h-4 -rotate-90" />
+                    <h2 className="text-base font-semibold">Choose your next task</h2>
+                </div>
+                <p className="text-xs text-gray-400 mb-2">
+                    {options.length} parallel options unlocked. Tap one to continue.
+                </p>
+
+                {options.map((opt) => {
+                    const node = opt.node;
+                    const firstImage = node.meta?.images?.[0];
+                    const notesSnippet = (node.meta?.notes ?? '').trim().split('\n')[0].slice(0, 90);
+                    return (
+                        <button
+                            key={`${opt.graphId}-${node.id}`}
+                            onClick={() => onSelect(opt)}
+                            className="w-full flex items-center gap-3 px-3 py-3 rounded-lg border border-slate-700/50 bg-slate-800/50 hover:border-purple-500/60 hover:bg-slate-800 transition-colors text-left touch:min-h-[64px]"
+                        >
+                            <div className="flex-shrink-0 w-12 h-12 rounded overflow-hidden bg-slate-900 border border-slate-700 flex items-center justify-center">
+                                {firstImage ? (
+                                    <img
+                                        src={firstImage.dataUrl}
+                                        alt={firstImage.name ?? node.title}
+                                        className="w-full h-full object-cover"
+                                    />
+                                ) : (
+                                    <ImageOff className="w-4 h-4 text-slate-600" />
+                                )}
+                            </div>
+                            <div className="flex-1 min-w-0">
+                                {opt.breadcrumb.length > 0 && (
+                                    <div className="text-[10px] uppercase tracking-wide text-indigo-400 truncate mb-0.5">
+                                        {opt.breadcrumb.join(' › ')}
+                                    </div>
+                                )}
+                                <div className="text-sm text-slate-100 font-medium line-clamp-2">
+                                    {node.title}
+                                </div>
+                                {notesSnippet && (
+                                    <div className="text-xs text-slate-400 truncate mt-0.5">
+                                        {notesSnippet}
+                                    </div>
+                                )}
+                            </div>
+                            <ChevronRight className="w-4 h-4 text-slate-500 flex-shrink-0" />
+                        </button>
+                    );
+                })}
+
+                <button
+                    onClick={onCancel}
+                    className="w-full mt-2 px-3 py-2 rounded-lg text-xs text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors"
+                >
+                    Cancel
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/src/components/FocusView/index.ts
+++ b/src/components/FocusView/index.ts
@@ -1,0 +1,2 @@
+export { FocusView } from './FocusView';
+export { ParallelChooser } from './ParallelChooser';

--- a/src/components/Layout/TopBar.tsx
+++ b/src/components/Layout/TopBar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useWorkspaceStore } from '../../store/workspaceStore';
-import { ChevronRight, Home, Undo2, Redo2, Trash2, BoxSelect, Link, Menu, LayoutGrid, List, MoreVertical, Eye, Zap, Maximize2 } from 'lucide-react';
+import { ChevronRight, Home, Undo2, Redo2, Trash2, BoxSelect, Link, Menu, LayoutGrid, List, Crosshair, MoreVertical, Eye, Zap, Maximize2 } from 'lucide-react';
 import { clsx } from 'clsx';
 import { useStore } from 'zustand';
 import { useDeviceDetect } from '../../hooks/useDeviceDetect';
@@ -108,6 +108,18 @@ export const TopBar: React.FC = () => {
                     >
                         <List className="w-4 h-4" />
                     </button>
+                    <button
+                        onClick={() => setViewMode('focus')}
+                        className={clsx(
+                            "p-1.5 rounded transition-colors touch:min-h-[44px] touch:min-w-[44px] touch:flex touch:flex-col touch:items-center touch:justify-center",
+                            viewMode === 'focus'
+                                ? "bg-gray-700 text-white"
+                                : "text-gray-400 hover:text-white"
+                        )}
+                        title="Focus view"
+                    >
+                        <Crosshair className="w-4 h-4" />
+                    </button>
                 </div>
                 )}
 
@@ -187,6 +199,17 @@ export const TopBar: React.FC = () => {
                                             <List className="w-4 h-4 flex-shrink-0" />
                                             List View
                                             {viewMode === 'list' && <span className="ml-auto text-purple-400 text-xs">Active</span>}
+                                        </button>
+                                        <button
+                                            onClick={() => { setViewMode('focus'); setOverflowOpen(false); }}
+                                            className={clsx(
+                                                "flex items-center gap-3 w-full px-4 py-3 text-sm text-left hover:bg-gray-700 transition-colors",
+                                                viewMode === 'focus' ? "text-white" : "text-gray-300"
+                                            )}
+                                        >
+                                            <Crosshair className="w-4 h-4 flex-shrink-0" />
+                                            Focus View
+                                            {viewMode === 'focus' && <span className="ml-auto text-purple-400 text-xs">Active</span>}
                                         </button>
                                         <div className="border-t border-gray-700 my-1" />
                                     </>

--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -21,7 +21,11 @@ interface WorkspaceState extends Workspace {
     connectMode: { active: boolean; sourceNodeId?: string };
     autoEditNodeId: string | null;
     sidebarOpen: boolean;
-    viewMode: 'graph' | 'list';
+    viewMode: 'graph' | 'list' | 'focus';
+
+    // Focus view session state (transient)
+    focusNodeId: string | null;
+    focusContextGraphId: string | null;
 
     // Sync status (transient)
     syncStatus: SyncStatus;
@@ -41,7 +45,9 @@ interface WorkspaceState extends Workspace {
     setAutoEditNodeId: (nodeId: string | null) => void;
     toggleSidebar: () => void;
     closeSidebar: () => void;
-    setViewMode: (mode: 'graph' | 'list') => void;
+    setViewMode: (mode: 'graph' | 'list' | 'focus') => void;
+    setFocusTask: (nodeId: string, graphId: string) => void;
+    clearFocusTask: () => void;
     loadProject: (projectId: string) => void;
     enterGraph: (graphId: string, nodeId: string, nodeLabel: string) => void;
     navigateBack: (steps?: number) => void;
@@ -98,6 +104,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             autoEditNodeId: null,
             sidebarOpen: false,
             viewMode: 'graph' as const,
+            focusNodeId: null,
+            focusContextGraphId: null,
             syncStatus: 'idle' as SyncStatus,
             syncError: null,
             lastSavedAt: null,
@@ -141,6 +149,14 @@ export const useWorkspaceStore = create<WorkspaceState>()(
 
             setViewMode: (mode) => {
                 set({ viewMode: mode });
+            },
+
+            setFocusTask: (nodeId, graphId) => {
+                set({ focusNodeId: nodeId, focusContextGraphId: graphId });
+            },
+
+            clearFocusTask: () => {
+                set({ focusNodeId: null, focusContextGraphId: null });
             },
 
             resetWorkspace: (seed = '42') => {
@@ -606,7 +622,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             storage: createJSONStorage(() => localStorage),
             partialize: (state) => {
                 // Exclude transient flags and actions from localStorage
-                const { _hydrated, _supabaseLoaded, selectMode, _hasSelection, connectMode, autoEditNodeId, sidebarOpen, viewMode, syncStatus, syncError, lastSavedAt, pendingCanvasAction, ...rest } = state;
+                const { _hydrated, _supabaseLoaded, selectMode, _hasSelection, connectMode, autoEditNodeId, sidebarOpen, viewMode, focusNodeId, focusContextGraphId, syncStatus, syncError, lastSavedAt, pendingCanvasAction, ...rest } = state;
                 return rest;
             },
             onRehydrateStorage: () => {

--- a/src/utils/logic.ts
+++ b/src/utils/logic.ts
@@ -74,3 +74,100 @@ export function isNodeActionable(node: Node, graph: Graph, graphs?: Record<strin
     if (isNodeBlocked(node, graph, graphs)) return false;
     return true;
 }
+
+/**
+ * Reference to a leaf action task discovered via container drill-in.
+ * `breadcrumb` lists the chain of container titles leading to this task
+ * so the focus view can present "Project > Container > Subcontainer".
+ */
+export interface FocusTaskRef {
+    node: Node;
+    graphId: string;
+    breadcrumb: string[];
+}
+
+/**
+ * Walks a graph (and any actionable containers' child graphs, recursively)
+ * collecting every leaf action node that is currently actionable. Containers
+ * themselves are never returned — focus view only presents leaf tasks.
+ *
+ * Order matches a depth-first traversal of the input graph's node array so
+ * containers are explored as we encounter them.
+ */
+export function getActionableLeafTasks(
+    graph: Graph,
+    graphs: Record<string, Graph>,
+    breadcrumb: string[] = []
+): FocusTaskRef[] {
+    if (!graph) return [];
+    const results: FocusTaskRef[] = [];
+    for (const node of graph.nodes) {
+        if (node.type === 'action') {
+            if (isNodeActionable(node, graph, graphs)) {
+                results.push({ node, graphId: graph.id, breadcrumb });
+            }
+        } else if (node.type === 'container' && node.childGraphId) {
+            // Only drill into containers that are themselves actionable
+            // (i.e. not blocked by external dependencies and not fully done).
+            if (!isNodeActionable(node, graph, graphs)) continue;
+            const childGraph = graphs[node.childGraphId];
+            if (!childGraph) continue;
+            results.push(
+                ...getActionableLeafTasks(childGraph, graphs, [...breadcrumb, node.title])
+            );
+        }
+    }
+    return results;
+}
+
+/**
+ * Given a just-completed leaf node, determine the next focus task(s).
+ *
+ * Returns:
+ *  - 0 entries → nothing left actionable in the active project (show "all done")
+ *  - 1 entry   → auto-advance to that task
+ *  - 2+ entries → render the parallel chooser
+ *
+ * Strategy: collect actionable successors of the completed node (including
+ * drilling into actionable containers). If none of the direct successors are
+ * actionable (e.g. they're still blocked by *other* incomplete predecessors),
+ * fall back to the global actionable set in the root graph.
+ */
+export function getNextFocusTasks(
+    completedNodeId: string,
+    completedGraphId: string,
+    rootGraph: Graph,
+    graphs: Record<string, Graph>
+): FocusTaskRef[] {
+    const completedGraph = graphs[completedGraphId];
+    if (!completedGraph) {
+        return getActionableLeafTasks(rootGraph, graphs);
+    }
+
+    const successors = completedGraph.edges
+        .filter(e => e.source === completedNodeId)
+        .map(e => completedGraph.nodes.find(n => n.id === e.target))
+        .filter((n): n is Node => !!n);
+
+    const direct: FocusTaskRef[] = [];
+    for (const s of successors) {
+        if (s.type === 'action') {
+            if (isNodeActionable(s, completedGraph, graphs)) {
+                direct.push({ node: s, graphId: completedGraph.id, breadcrumb: [] });
+            }
+        } else if (s.type === 'container' && s.childGraphId) {
+            if (!isNodeActionable(s, completedGraph, graphs)) continue;
+            const childGraph = graphs[s.childGraphId];
+            if (!childGraph) continue;
+            direct.push(...getActionableLeafTasks(childGraph, graphs, [s.title]));
+        }
+    }
+
+    if (direct.length > 0) return direct;
+
+    // No direct successors actionable (blocked by other things, or none exist).
+    // Fall back to the next actionable task anywhere in the root graph,
+    // excluding the just-completed node.
+    return getActionableLeafTasks(rootGraph, graphs)
+        .filter(t => t.node.id !== completedNodeId);
+}


### PR DESCRIPTION
Adds a third view mode alongside Node and List view that puts one task on
screen at a time: hero image (top), scrollable notes (bottom), and a
prominent status pill that auto-advances to the next actionable task on
completion. Containers are transparently drilled — only leaf tasks are
shown — and a condensed ParallelChooser appears when a completed task
unblocks more than one successor.

Also includes Skip / Prev controls (with in-memory history for undoing
mis-taps), a combined notes-and-images Edit modal, an "all tasks complete"
celebration screen, and desktop keyboard shortcuts (Space/Enter cycle
status, ←/→ prev/skip, Esc back to list).

QA docs updated: new test cases QA-B035 through QA-B043, refreshed view
mode summaries, and the inventory now lists FocusView / ParallelChooser
plus relevant risk areas.

https://claude.ai/code/session_01RJScaW11dgsAcvTntc2Zq8