### PR TITLE
Add Predecessor Trace: surface blockers on blocked nodes

### DIFF
--- a/EXPECTED_UI_BEHAVIORS.md
+++ b/EXPECTED_UI_BEHAVIORS.md
@@ -209,9 +209,21 @@ All shortcuts should only fire when the canvas has focus (not when typing in an 
 
 - **Click the status icon** (left side of an action node) → cycles through: Todo → In Progress → Done → Todo.
 - The status icon should update immediately with appropriate visual feedback (icon change, color change).
-- **Blocked nodes** (those with unsatisfied dependencies) should show a lock icon and should NOT allow status changes. The cursor should indicate the interaction is disabled.
+- **Blocked nodes** (those with unsatisfied dependencies) show a lock icon in place of the status circle. Clicking the lock does NOT cycle status — it surfaces the blockers (see §11a).
 - Cycling status should be a single-click action — no menus or extra steps.
 - Status can also be set via right-click context menu → Set Status submenu, which allows jumping directly to any status.
+
+## 11a. Blocked Node Interaction ("Why is this blocked?")
+
+- Every node with unsatisfied predecessors shows a red **"Blocked"** badge on its top-right corner in addition to the lock on the status icon.
+- **Clicking the lock icon OR the "Blocked" badge** on a blocked node opens the **predecessor trace**:
+  - Each blocking predecessor gets a red pulse ring (2 cycles, ~2.4s) overlayed on its node.
+  - The viewport auto-fits to include the blocked node and its blockers (400ms animation).
+  - A chip bar anchored under the blocked node lists each blocker: `Blocked by <Title>`. Container blockers show progress: `<Title> (42%)`.
+  - On small/touch screens, the chip bar is replaced by a bottom sheet with 44×44 tap targets.
+- **Clicking a blocker chip/row** dismisses the spotlight and frames the blocker on screen (and selects it when possible).
+- **Dismissal**: Esc, clicking empty canvas, the × button on the chip bar, or after a 4-second timeout.
+- Blocker resolution is refreshed on each open — stale blockers won't be shown.
 
 ---
 

--- a/QA_INVENTORY.md
+++ b/QA_INVENTORY.md
@@ -30,14 +30,15 @@ No URL router — single-page app with in-memory navigation stack.
 | Focus View | viewMode='focus'; one task at a time with image, notes, status; auto-advances on done | `FocusView.tsx` + `ParallelChooser.tsx` |
 | Execution Mode | executionMode toggle | `CanvasArea.tsx` + `StepDetailPanel.tsx` |
 
-## Components (23 total)
+## Components (24 total)
 
 ### Canvas & Nodes
 | Component | File | Purpose |
 |-----------|------|---------|
 | CanvasArea | `src/components/Canvas/CanvasArea.tsx` | ReactFlow canvas, pan/zoom, shortcuts, touch gestures |
-| ActionNode | `src/components/Nodes/ActionNode.tsx` | Task node: status cycle, inline edit, resize, notes, images |
-| ContainerNode | `src/components/Nodes/ContainerNode.tsx` | Folder node: progress ring, magic expand, enter subgraph, images |
+| BlockedSpotlight | `src/components/Canvas/BlockedSpotlight.tsx` | Predecessor-trace overlay: pulse rings on blockers + chip bar / bottom sheet |
+| ActionNode | `src/components/Nodes/ActionNode.tsx` | Task node: status cycle, inline edit, resize, notes, images, interactive blocked badge |
+| ContainerNode | `src/components/Nodes/ContainerNode.tsx` | Folder node: progress ring, magic expand, enter subgraph, images, interactive blocked badge |
 | NotesEditor | `src/components/Nodes/NotesEditor.tsx` | Notes popover/modal for nodes |
 | ImagesEditor | `src/components/Nodes/ImagesEditor.tsx` | Visual References panel: inline thumbnail grid, upload, remove, with persisted open/closed state |
 | ImageLightbox | `src/components/Nodes/ImageLightbox.tsx` | Fullscreen image viewer with keyboard/arrow navigation |

--- a/SPATIAL_TASKS_QA_GUIDE.md
+++ b/SPATIAL_TASKS_QA_GUIDE.md
@@ -1321,3 +1321,20 @@ The following test cases verify fixes from the codebase audit (`SPATIAL_TASKS_CO
 | AF-13 | FlowGenerator loads on demand | 1. Click "Generate Flow" button | FlowGenerator chunk loads; modal opens correctly |
 | AF-14 | MarkdownImporter loads on demand | 1. Click "Import Plan" button | MarkdownImporter chunk loads; modal opens correctly |
 | AF-15 | Build produces multiple chunks | 1. Run `npm run build` | Output shows separate chunks for react-flow, supabase, and lazy-loaded modals |
+
+### Feature: Predecessor Trace ("Why is this blocked?")
+
+**What changed:** Clicking the lock icon or "Blocked" badge on a blocked node now surfaces which predecessors are blocking it with red pulse rings, a fitView, and a chip bar / bottom sheet listing the blockers by title.
+
+| # | Test Case | Steps | Expected Result |
+|---|-----------|-------|-----------------|
+| PT-1 | Single blocker (action) | 1. Open Morning Flow System → Breakfast subgraph 2. Click the lock icon on "Eat" | Cook gets a red pulse ring; viewport fits Eat + Cook; chip bar "Blocked by Cook" appears under Eat |
+| PT-2 | Container blocker shows progress | 1. On root graph, click the "Blocked" badge on Breakfast | Workout pulses; chip shows "Blocked by Workout (25%)" |
+| PT-3 | Chain of 3 blockers | 1. Build a graph A → B → C → D where A is todo 2. Click lock on D | Only C appears as a blocker (direct predecessor only); clicking C's chip frames C, which can itself be opened to reveal B |
+| PT-4 | Dismiss via Esc | 1. Trigger a blocker spotlight 2. Press Esc | Chip bar/bottom sheet closes; pulse rings stop |
+| PT-5 | Dismiss by clicking empty canvas | 1. Trigger spotlight 2. Click empty canvas pane | Chip bar closes; spotlight clears |
+| PT-6 | Auto-dismiss after 4s | 1. Trigger spotlight 2. Do nothing for 4+ seconds | Chip bar disappears; pulse rings fade |
+| PT-7 | Chip click jumps to blocker | 1. Trigger spotlight on Eat 2. Click the "Cook" chip | Spotlight closes; viewport re-frames Cook |
+| PT-8 | Touch: bottom sheet instead of chip bar | 1. On mobile/touch device, tap the "Blocked" badge on a blocked node | Bottom sheet slides up listing blockers with ≥44px tap targets |
+| PT-9 | Blocked state stays blocked after predecessor partial complete | 1. Mark some (not all) leaves of a container predecessor done 2. Click downstream node's blocker | Chip still lists the container with updated percentage |
+| PT-10 | Unblocked nodes show no badge | 1. Mark all predecessors done on a previously-blocked node | "Blocked" badge and lock icon disappear; status cycling works again |

--- a/src/components/Canvas/BlockedSpotlight.tsx
+++ b/src/components/Canvas/BlockedSpotlight.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ChevronRight, X } from 'lucide-react';
+import { useWorkspaceStore } from '../../store/workspaceStore';
+import type { BlockingNodeInfo } from '../../utils/logic';
+
+const DISMISS_AFTER_MS = 4000;
+const PULSE_CLASS = 'blocker-pulse';
+
+interface BlockedSpotlightProps {
+    sourceNodeId: string;
+    blockers: BlockingNodeInfo[];
+    /** Map of blocker node id → display title (prefetched by caller from graph). */
+    titles: Record<string, string>;
+    isSmallScreen: boolean;
+    onDismiss: () => void;
+    onJumpTo: (blockerId: string) => void;
+}
+
+/**
+ * Red pulse rings on blocker nodes + a chip bar under the selected node
+ * (or a bottom sheet on small screens) listing the blockers.
+ * Auto-dismisses after 4s or on Esc.
+ */
+export function BlockedSpotlight({
+    sourceNodeId,
+    blockers,
+    titles,
+    isSmallScreen,
+    onDismiss,
+    onJumpTo,
+}: BlockedSpotlightProps) {
+    const [sourceRect, setSourceRect] = useState<DOMRect | null>(null);
+
+    // Apply pulse class to blocker DOM nodes while the spotlight is active.
+    useEffect(() => {
+        const added: Element[] = [];
+        for (const b of blockers) {
+            const el = document.querySelector(`.react-flow__node[data-id="${cssEscape(b.nodeId)}"]`);
+            if (el) {
+                el.classList.add(PULSE_CLASS);
+                added.push(el);
+            }
+        }
+        return () => {
+            for (const el of added) el.classList.remove(PULSE_CLASS);
+        };
+    }, [blockers]);
+
+    // Esc-to-dismiss + auto-dismiss timer.
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                e.stopPropagation();
+                onDismiss();
+            }
+        };
+        const timer = window.setTimeout(onDismiss, DISMISS_AFTER_MS);
+        document.addEventListener('keydown', onKey, true);
+        return () => {
+            window.clearTimeout(timer);
+            document.removeEventListener('keydown', onKey, true);
+        };
+    }, [onDismiss]);
+
+    // Track the source node's on-screen rect during and after fitView animation.
+    useEffect(() => {
+        if (isSmallScreen) return;
+        const read = () => {
+            const el = document.querySelector(`.react-flow__node[data-id="${cssEscape(sourceNodeId)}"]`);
+            if (el) setSourceRect(el.getBoundingClientRect());
+        };
+        // Read immediately, then poll for the duration of the fitView animation.
+        read();
+        const interval = window.setInterval(read, 50);
+        const stop = window.setTimeout(() => window.clearInterval(interval), 600);
+        return () => {
+            window.clearInterval(interval);
+            window.clearTimeout(stop);
+        };
+    }, [sourceNodeId, isSmallScreen]);
+
+    if (isSmallScreen) {
+        return createPortal(<BottomSheet blockers={blockers} titles={titles} onDismiss={onDismiss} onJumpTo={onJumpTo} />, document.body);
+    }
+
+    if (!sourceRect) return null;
+
+    return createPortal(
+        <ChipBar
+            blockers={blockers}
+            titles={titles}
+            sourceRect={sourceRect}
+            onDismiss={onDismiss}
+            onJumpTo={onJumpTo}
+        />,
+        document.body,
+    );
+}
+
+interface BarProps {
+    blockers: BlockingNodeInfo[];
+    titles: Record<string, string>;
+    onDismiss: () => void;
+    onJumpTo: (blockerId: string) => void;
+}
+
+function ChipBar({ sourceRect, blockers, titles, onDismiss, onJumpTo }: BarProps & { sourceRect: DOMRect }) {
+    const top = sourceRect.bottom + 8;
+    const left = Math.max(12, Math.min(window.innerWidth - 12, sourceRect.left + sourceRect.width / 2));
+
+    return (
+        <div
+            role="group"
+            aria-label="Blockers"
+            className="fixed z-[90] -translate-x-1/2 flex items-center gap-1.5 px-2 py-1.5 rounded-xl bg-slate-900/95 border border-red-700/70 shadow-[0_4px_20px_rgba(0,0,0,0.6)] animate-slide-in-left"
+            style={{ top, left, maxWidth: 'calc(100vw - 24px)' }}
+            onMouseDown={e => e.stopPropagation()}
+        >
+            <span className="text-[11px] text-red-200 font-medium whitespace-nowrap pl-1">Blocked by</span>
+            <div className="flex items-center gap-1 flex-wrap">
+                {blockers.map(b => (
+                    <BlockerChip key={b.nodeId} blocker={b} title={titles[b.nodeId]} onJumpTo={onJumpTo} />
+                ))}
+            </div>
+            <button
+                onClick={onDismiss}
+                aria-label="Dismiss blockers hint"
+                className="ml-1 p-1 rounded-md text-slate-400 hover:text-slate-100 hover:bg-slate-800 touch:min-h-[44px] touch:min-w-[44px]"
+            >
+                <X className="w-3.5 h-3.5" />
+            </button>
+        </div>
+    );
+}
+
+function BottomSheet({ blockers, titles, onDismiss, onJumpTo }: BarProps) {
+    return (
+        <div className="fixed inset-x-0 bottom-0 z-[90] bg-slate-900 border-t border-red-700/60 shadow-[0_-4px_20px_rgba(0,0,0,0.6)] animate-slide-in" style={{ paddingBottom: 'calc(12px + var(--sab, 0px))' }}>
+            <div className="flex items-center justify-between px-4 pt-3 pb-2">
+                <h3 className="text-sm font-semibold text-red-200">Blocked by</h3>
+                <button
+                    onClick={onDismiss}
+                    aria-label="Dismiss blockers hint"
+                    className="p-2 rounded-md text-slate-400 hover:text-slate-100 hover:bg-slate-800 min-h-[44px] min-w-[44px] flex items-center justify-center"
+                >
+                    <X className="w-4 h-4" />
+                </button>
+            </div>
+            <ul className="px-3 pb-3 flex flex-col gap-1.5">
+                {blockers.map(b => (
+                    <li key={b.nodeId}>
+                        <button
+                            onClick={() => onJumpTo(b.nodeId)}
+                            className="w-full min-h-[44px] flex items-center justify-between gap-2 px-3 py-2 rounded-md bg-slate-800 hover:bg-slate-700 text-left border border-slate-700"
+                        >
+                            <span className="text-sm text-slate-100 truncate">{formatBlockerLabel(b, titles[b.nodeId])}</span>
+                            <ChevronRight className="w-4 h-4 text-slate-400 flex-shrink-0" />
+                        </button>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+function BlockerChip({ blocker, title, onJumpTo }: { blocker: BlockingNodeInfo; title?: string; onJumpTo: (id: string) => void }) {
+    return (
+        <button
+            onClick={() => onJumpTo(blocker.nodeId)}
+            className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-red-900/40 border border-red-700/60 text-[11px] text-red-100 hover:bg-red-900/70 hover:border-red-600 max-w-[220px] touch:min-h-[32px]"
+            title={`Jump to "${title ?? 'blocker'}"`}
+        >
+            <span className="truncate">{formatBlockerLabel(blocker, title)}</span>
+        </button>
+    );
+}
+
+function formatBlockerLabel(b: BlockingNodeInfo, title?: string): string {
+    const safeTitle = title ?? '…';
+    if (b.reason === 'partial-container' && typeof b.progress === 'number') {
+        const pct = Math.round(b.progress * 100);
+        return `${safeTitle} (${pct}%)`;
+    }
+    return safeTitle;
+}
+
+/** Minimal CSS selector escape for node UUIDs (safe subset — alnum + dash). */
+function cssEscape(id: string): string {
+    return id.replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+}
+
+// Re-export to keep callers terse.
+export function useBlockingTitles(blockers: BlockingNodeInfo[]): Record<string, string> {
+    const graphs = useWorkspaceStore(s => s.graphs);
+    const activeGraphId = useWorkspaceStore(s => s.activeGraphId);
+    return useMemo(() => {
+        const graph = activeGraphId ? graphs[activeGraphId] : undefined;
+        if (!graph) return {};
+        const out: Record<string, string> = {};
+        for (const b of blockers) {
+            const node = graph.nodes.find(n => n.id === b.nodeId);
+            if (node) out[b.nodeId] = node.title;
+        }
+        return out;
+    }, [blockers, graphs, activeGraphId]);
+}

--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -21,8 +21,9 @@ import { ActionSheet } from '../UI/ActionSheet';
 import { FloatingActionButton } from '../UI/FloatingActionButton';
 import { Trash2, Circle, Clock, CheckCircle2, Plus, Layers, MousePointerClick, Sparkles, Maximize2 } from 'lucide-react';
 import { useDeviceDetect } from '../../hooks/useDeviceDetect';
-import { isNodeActionable } from '../../utils/logic';
+import { isNodeActionable, getBlockingNodes, BlockingNodeInfo } from '../../utils/logic';
 import { StepDetailPanel } from '../ExecutionPanel/StepDetailPanel';
+import { BlockedSpotlight, useBlockingTitles } from './BlockedSpotlight';
 
 const nodeTypes = {
     container: ContainerNode,
@@ -85,6 +86,13 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
         message: string;
         onConfirm: () => void;
     } | null>(null);
+
+    // Blocked-by spotlight state (transient UI state, not persisted)
+    const [spotlight, setSpotlight] = useState<{
+        sourceNodeId: string;
+        blockers: BlockingNodeInfo[];
+    } | null>(null);
+    const spotlightTitles = useBlockingTitles(spotlight?.blockers ?? []);
 
     const graph = activeGraphId ? graphs[activeGraphId] : null;
 
@@ -410,6 +418,42 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
             deleteSelected();
         } else if (action.type === 'fit-view') {
             handleFitView();
+        } else if (action.type === 'spotlight-blockers') {
+            if (!activeGraphId) return;
+            const currentGraph = useWorkspaceStore.getState().graphs[activeGraphId];
+            if (!currentGraph) return;
+            const allGraphs = useWorkspaceStore.getState().graphs;
+            const sourceNode = currentGraph.nodes.find(n => n.id === action.sourceNodeId);
+            if (!sourceNode) return;
+            const freshBlockers = getBlockingNodes(sourceNode, currentGraph, allGraphs);
+            if (freshBlockers.length === 0) return;
+
+            setSpotlight({ sourceNodeId: action.sourceNodeId, blockers: freshBlockers });
+
+            // Fit view to include the source + its blockers.
+            const idsToFit = [action.sourceNodeId, ...freshBlockers.map(b => b.nodeId)];
+            const rfNodes = reactFlowInstance.getNodes();
+            const nodesToFit = rfNodes.filter(n => idsToFit.includes(n.id));
+            if (nodesToFit.length > 0) {
+                reactFlowInstance.fitView({
+                    nodes: nodesToFit,
+                    padding: 0.3,
+                    duration: 400,
+                    maxZoom: 1.5,
+                });
+            }
+        } else if (action.type === 'select-and-frame') {
+            const rfNodes = reactFlowInstance.getNodes();
+            const rfNode = rfNodes.find(n => n.id === action.nodeId);
+            if (!rfNode) return;
+            reactFlowInstance.setNodes(rfNodes.map(n => ({ ...n, selected: n.id === action.nodeId })));
+            setHasSelection(true);
+            reactFlowInstance.fitView({
+                nodes: [rfNode],
+                padding: 0.4,
+                duration: 300,
+                maxZoom: 1.5,
+            });
         } else if (action.type === 'advance-next') {
             const fromNodeId = action.fromNodeId;
             if (!activeGraphId) return;
@@ -805,7 +849,7 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
                 onNodesChange={onNodesChange}
                 onConnect={onConnect}
                 onNodeClick={handleNodeClick}
-                onPaneClick={() => { setQuickAdd(null); setContextMenu(null); setActionSheet(null); if (connectMode.active) clearConnectMode(); }}
+                onPaneClick={() => { setQuickAdd(null); setContextMenu(null); setActionSheet(null); setSpotlight(null); if (connectMode.active) clearConnectMode(); }}
                 onDoubleClick={isTouchDevice ? undefined : handlePaneDoubleClick}
                 onNodeContextMenu={handleNodeContextMenu}
                 onEdgeContextMenu={handleEdgeContextMenu}
@@ -953,6 +997,21 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
 
             {/* Execution mode step detail panel */}
             <StepDetailPanel />
+
+            {/* Predecessor Trace — blocked-by spotlight */}
+            {spotlight && (
+                <BlockedSpotlight
+                    sourceNodeId={spotlight.sourceNodeId}
+                    blockers={spotlight.blockers}
+                    titles={spotlightTitles}
+                    isSmallScreen={isTouchDevice}
+                    onDismiss={() => setSpotlight(null)}
+                    onJumpTo={(blockerId) => {
+                        setSpotlight(null);
+                        useWorkspaceStore.getState().dispatchCanvasAction({ type: 'select-and-frame', nodeId: blockerId });
+                    }}
+                />
+            )}
         </div>
     );
 };

--- a/src/components/Nodes/ActionNode.tsx
+++ b/src/components/Nodes/ActionNode.tsx
@@ -6,7 +6,7 @@ import { NotesEditor } from './NotesEditor';
 import { ImagesEditor } from './ImagesEditor';
 import { clsx } from 'clsx';
 import { useWorkspaceStore } from '../../store/workspaceStore';
-import { isNodeBlocked, isNodeActionable } from '../../utils/logic';
+import { getBlockingNodes, isNodeActionable } from '../../utils/logic';
 import { useDeviceDetect } from '../../hooks/useDeviceDetect';
 
 const MIN_WIDTH = 140;
@@ -51,13 +51,15 @@ export const ActionNode = memo(({ data, selected }: NodeProps<Node>) => {
         }
     }, [autoEditNodeId, data.id, data.title, setAutoEditNodeId]);
 
-    const { isBlocked, isActionable } = useMemo(() => {
+    const { isBlocked, isActionable, blockers } = useMemo(() => {
         const graphId = activeGraphId ?? data.graphId;
         const graph = graphId ? graphs[graphId] : undefined;
-        if (!graph) return { isBlocked: false, isActionable: false };
+        if (!graph) return { isBlocked: false, isActionable: false, blockers: [] };
+        const b = getBlockingNodes(data, graph, graphs);
         return {
-            isBlocked: isNodeBlocked(data, graph, graphs),
+            isBlocked: b.length > 0,
             isActionable: isNodeActionable(data, graph, graphs),
+            blockers: b,
         };
     }, [data, activeGraphId, graphs]);
 
@@ -68,10 +70,18 @@ export const ActionNode = memo(({ data, selected }: NodeProps<Node>) => {
 
     const handleStatusClick = useCallback((e: React.MouseEvent) => {
         e.stopPropagation();
-        if (isBlocked) return;
+        if (isBlocked) {
+            dispatchCanvasAction({
+                type: 'spotlight-blockers',
+                sourceNodeId: data.id,
+                blockerIds: blockers.map(b => b.nodeId),
+            });
+            try { navigator.vibrate(10); } catch {}
+            return;
+        }
         cycleNodeStatus(data.id);
         try { navigator.vibrate(10); } catch {}
-    }, [isBlocked, cycleNodeStatus, data.id]);
+    }, [isBlocked, blockers, cycleNodeStatus, dispatchCanvasAction, data.id]);
 
     const save = useCallback(() => {
         if (editValue.trim() && editValue.trim() !== data.title) {
@@ -158,11 +168,9 @@ export const ActionNode = memo(({ data, selected }: NodeProps<Node>) => {
             <div className="flex items-start gap-2">
                 <button
                     onClick={handleStatusClick}
-                    className={clsx(
-                        "flex-shrink-0 hover:scale-125 transition-transform touch:min-h-[44px] touch:min-w-[44px] touch:flex touch:items-center touch:justify-center mt-0.5",
-                        isBlocked ? "cursor-not-allowed" : "cursor-pointer"
-                    )}
-                    title={isBlocked ? "Blocked" : "Click to cycle status"}
+                    className="flex-shrink-0 hover:scale-125 transition-transform touch:min-h-[44px] touch:min-w-[44px] touch:flex touch:items-center touch:justify-center mt-0.5 cursor-pointer"
+                    title={isBlocked ? "Show blockers" : "Click to cycle status"}
+                    aria-label={isBlocked ? "Show blockers" : "Cycle status"}
                 >
                     <StatusIcon status={data.status} blocked={isBlocked} />
                 </button>
@@ -269,9 +277,21 @@ export const ActionNode = memo(({ data, selected }: NodeProps<Node>) => {
             )}
 
             {isBlocked && (
-                <div className="absolute -top-2 -right-2 bg-red-900/80 text-red-200 text-[10px] px-1.5 py-0.5 rounded-full border border-red-800">
+                <button
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        dispatchCanvasAction({
+                            type: 'spotlight-blockers',
+                            sourceNodeId: data.id,
+                            blockerIds: blockers.map(b => b.nodeId),
+                        });
+                    }}
+                    className="absolute -top-2 -right-2 bg-red-900/80 text-red-200 text-[10px] px-1.5 py-0.5 rounded-full border border-red-800 hover:bg-red-800 hover:text-red-100 transition-colors touch:min-h-[28px]"
+                    title={`Blocked by ${blockers.length} predecessor${blockers.length === 1 ? '' : 's'}`}
+                    aria-label="Show blockers"
+                >
                     Blocked
-                </div>
+                </button>
             )}
 
             {highlight && (

--- a/src/components/Nodes/ContainerNode.tsx
+++ b/src/components/Nodes/ContainerNode.tsx
@@ -8,7 +8,7 @@ import { clsx } from 'clsx';
 import { v4 as uuidv4 } from 'uuid';
 import { useWorkspaceStore } from '../../store/workspaceStore';
 import { useToastStore } from '../UI/Toast';
-import { getContainerProgress, isNodeBlocked } from '../../utils/logic';
+import { getContainerProgress, getBlockingNodes } from '../../utils/logic';
 import { magicExpand, GeminiError } from '../../services/gemini';
 import { ConfirmModal } from '../UI/ConfirmModal';
 import { useDeviceDetect } from '../../hooks/useDeviceDetect';
@@ -42,6 +42,7 @@ export const ContainerNode = memo(({ data, selected }: NodeProps<SpatialNode>) =
     const updateSettings = useWorkspaceStore(state => state.updateSettings);
     const autoEditNodeId = useWorkspaceStore(state => state.autoEditNodeId);
     const setAutoEditNodeId = useWorkspaceStore(state => state.setAutoEditNodeId);
+    const dispatchCanvasAction = useWorkspaceStore(state => state.dispatchCanvasAction);
     const addToast = useToastStore(state => state.addToast);
 
     const [expanding, setExpanding] = useState(false);
@@ -69,12 +70,17 @@ export const ContainerNode = memo(({ data, selected }: NodeProps<SpatialNode>) =
         return getContainerProgress(data, { graphs } as any);
     }, [data, graphs]);
 
-    const isActionable = useMemo(() => {
+    const blockers = useMemo(() => {
         const graphId = activeGraphId ?? data.graphId;
         const graph = graphId ? graphs[graphId] : undefined;
-        const blocked = graph ? isNodeBlocked(data, graph, graphs) : false;
-        return !blocked && progress < 1;
-    }, [data, activeGraphId, graphs, progress]);
+        return graph ? getBlockingNodes(data, graph, graphs) : [];
+    }, [data, activeGraphId, graphs]);
+
+    const isBlocked = blockers.length > 0;
+
+    const isActionable = useMemo(() => {
+        return !isBlocked && progress < 1;
+    }, [isBlocked, progress]);
 
     const highlight = executionMode && isActionable;
     const dim = executionMode && !isActionable;
@@ -346,6 +352,24 @@ export const ContainerNode = memo(({ data, selected }: NodeProps<SpatialNode>) =
                 >
                     <ArrowBigRightDash className="w-3 h-3" />
                     Dive In
+                </button>
+            )}
+
+            {isBlocked && !highlight && (
+                <button
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        dispatchCanvasAction({
+                            type: 'spotlight-blockers',
+                            sourceNodeId: data.id,
+                            blockerIds: blockers.map(b => b.nodeId),
+                        });
+                    }}
+                    className="absolute -top-2 -right-2 bg-red-900/80 text-red-200 text-[10px] px-1.5 py-0.5 rounded-full border border-red-800 hover:bg-red-800 hover:text-red-100 transition-colors z-20 touch:min-h-[28px]"
+                    title={`Blocked by ${blockers.length} predecessor${blockers.length === 1 ? '' : 's'}`}
+                    aria-label="Show blockers"
+                >
+                    Blocked
                 </button>
             )}
 

--- a/src/index.css
+++ b/src/index.css
@@ -146,3 +146,13 @@ html, body, #root {
 .animate-slide-in-left {
     animation: slide-in-left 0.2s ease-out;
 }
+
+/* Blocked-by spotlight — red pulse outline around blocker nodes. */
+@keyframes blocker-pulse {
+    0%, 100% { box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.9), 0 0 18px 4px rgba(248, 113, 113, 0.35); }
+    50%      { box-shadow: 0 0 0 4px rgba(248, 113, 113, 0.95), 0 0 28px 8px rgba(248, 113, 113, 0.55); }
+}
+.blocker-pulse {
+    animation: blocker-pulse 1.2s ease-in-out 2;
+    border-radius: 0.5rem;
+}

--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -10,7 +10,9 @@ export type SyncStatus = 'idle' | 'saving' | 'saved' | 'error';
 export type CanvasAction =
     | { type: 'delete-selected' }
     | { type: 'fit-view' }
-    | { type: 'advance-next'; fromNodeId: string };
+    | { type: 'advance-next'; fromNodeId: string }
+    | { type: 'spotlight-blockers'; sourceNodeId: string; blockerIds: string[] }
+    | { type: 'select-and-frame'; nodeId: string };
 
 interface WorkspaceState extends Workspace {
     // Transient flags (not persisted)

--- a/src/utils/logic.ts
+++ b/src/utils/logic.ts
@@ -15,25 +15,50 @@ function isDependencySatisfied(sourceNode: Node, graphs?: Record<string, Graph>)
 }
 
 /**
+ * Describes a predecessor that is currently blocking `node`.
+ * `reason` distinguishes a plain incomplete action from a partially-complete
+ * container so the UI can render them differently ("Container X (3/5 done)").
+ */
+export interface BlockingNodeInfo {
+    nodeId: string;
+    reason: 'incomplete' | 'partial-container';
+    progress?: number; // 0..1, only for partial-container
+}
+
+/**
+ * Returns every predecessor that currently blocks `node`. Empty array ≙ not blocked.
+ * Call sites that only need a boolean should use `isNodeBlocked`.
+ */
+export function getBlockingNodes(node: Node, graph: Graph, graphs?: Record<string, Graph>): BlockingNodeInfo[] {
+    if (!graph) return [];
+
+    const blockers: BlockingNodeInfo[] = [];
+    const incomingEdges = graph.edges.filter(e => e.target === node.id);
+
+    for (const edge of incomingEdges) {
+        const sourceNode = graph.nodes.find(n => n.id === edge.source);
+        if (!sourceNode) continue;
+        if (isDependencySatisfied(sourceNode, graphs)) continue;
+
+        if (sourceNode.type === 'container' && graphs) {
+            const progress = getContainerProgress(sourceNode, { graphs } as Workspace);
+            blockers.push({ nodeId: sourceNode.id, reason: 'partial-container', progress });
+        } else {
+            blockers.push({ nodeId: sourceNode.id, reason: 'incomplete' });
+        }
+    }
+
+    return blockers;
+}
+
+/**
  * Checks if a node is blocked by any incoming dependencies.
  * A node is blocked if it has any incoming edges from nodes that are not yet satisfied.
  *
  * @param graphs - Pass workspace `graphs` so container predecessors can be evaluated by child progress.
  */
 export function isNodeBlocked(node: Node, graph: Graph, graphs?: Record<string, Graph>): boolean {
-    if (!graph) return false;
-
-    const incomingEdges = graph.edges.filter(e => e.target === node.id);
-
-    for (const edge of incomingEdges) {
-        const sourceNode = graph.nodes.find(n => n.id === edge.source);
-
-        if (sourceNode && !isDependencySatisfied(sourceNode, graphs)) {
-            return true;
-        }
-    }
-
-    return false;
+    return getBlockingNodes(node, graph, graphs).length > 0;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Feature 1.1 / Item 1** from [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) (companion to [FEATURE_OPPORTUNITIES.md §1.1](FEATURE_OPPORTUNITIES.md))
- Clicking the lock icon or "Blocked" badge on a blocked node now highlights each blocking predecessor with a red pulse ring, auto-fits the viewport to include the blocker(s), and shows a chip bar (desktop) or bottom sheet (touch) listing blockers by title.
- Container blockers are labeled with progress: `Workout (25%)`.
- Refactors `isNodeBlocked` → `getBlockingNodes` (boolean wrapper preserved for existing call sites).

## Motivation

`isNodeBlocked()` returned a boolean — users saw a lock icon but never learned *which* predecessor was blocking them. This converts the dependency graph from decorative into diagnostic. No new persisted state; derived at render time.

## Changes

- `src/utils/logic.ts` — added `getBlockingNodes` + `BlockingNodeInfo` type; `isNodeBlocked` is now a one-liner wrapper.
- `src/components/Canvas/BlockedSpotlight.tsx` (new) — pulse-ring application, chip bar / bottom sheet, portal + rAF positioning, Esc + click-outside + 4s timeout dismissal.
- `src/components/Canvas/CanvasArea.tsx` — handles `spotlight-blockers` and `select-and-frame` canvas actions.
- `src/components/Nodes/ActionNode.tsx` + `ContainerNode.tsx` — lock + "Blocked" badge both dispatch the spotlight.
- `src/store/workspaceStore.ts` — two new `CanvasAction` variants.
- `src/index.css` — `blocker-pulse` keyframe (2 cycles, ~2.4s).
- Docs: EXPECTED_UI_BEHAVIORS §11a, SPATIAL_TASKS_QA_GUIDE PT-1..PT-10, QA_INVENTORY component list.

## Test plan

- [ ] Root graph: click "Blocked" badge on a blocked container → predecessor pulses with progress label
- [ ] Drill into Breakfast subgraph: click lock on "Eat" → "Cook" pulses; chip shows "Blocked by Cook"
- [ ] Chip click → viewport reframes on the blocker
- [ ] Esc dismisses the spotlight
- [ ] Clicking empty canvas dismisses the spotlight
- [ ] 4-second auto-dismiss works
- [ ] Touch viewport: bottom sheet appears instead of chip bar
- [ ] `npm run build` passes (TypeScript compile clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)