### PR TITLE
Add node accent colors (7-color palette)

### DIFF
--- a/EXPECTED_UI_BEHAVIORS.md
+++ b/EXPECTED_UI_BEHAVIORS.md
@@ -205,6 +205,17 @@ All shortcuts should only fire when the canvas has focus (not when typing in an 
 
 ---
 
+## 10a. Accent Colors
+
+- Every node can be tagged with one of 7 accent colors (gray, red, amber, green, blue, purple, pink) or left uncolored. The accent has **no semantic meaning** — no filtering, no dependency behavior. It is a purely visual categorization tool.
+- Accent is set via the node's context menu (desktop right-click) or action sheet (touch long-press): **Set Color → [swatch row]**. The "No color" option clears the accent.
+- Multi-select context menu also offers a batch "Set Color" submenu that applies to every selected node in a single undo step.
+- **Graph view**: the accent renders as a 3px left-edge bar inside the node card. Nodes without an accent are visually identical to pre-feature.
+- **List view**: the accent renders as an 8px dot next to the title.
+- Accent persists through Zustand `persist` (localStorage) and Supabase sync, and is undo/redo-tracked.
+
+---
+
 ## 11. Status Cycling
 
 - **Click the status icon** (left side of an action node) → cycles through: Todo → In Progress → Done → Todo.

--- a/SPATIAL_TASKS_QA_GUIDE.md
+++ b/SPATIAL_TASKS_QA_GUIDE.md
@@ -1321,3 +1321,17 @@ The following test cases verify fixes from the codebase audit (`SPATIAL_TASKS_CO
 | AF-13 | FlowGenerator loads on demand | 1. Click "Generate Flow" button | FlowGenerator chunk loads; modal opens correctly |
 | AF-14 | MarkdownImporter loads on demand | 1. Click "Import Plan" button | MarkdownImporter chunk loads; modal opens correctly |
 | AF-15 | Build produces multiple chunks | 1. Run `npm run build` | Output shows separate chunks for react-flow, supabase, and lazy-loaded modals |
+
+### Feature: Node Accent Colors
+
+**What changed:** Nodes can be tagged with one of 7 accent colors via context menu / action sheet. Accent renders as a 3px left-edge bar in graph view and an 8px dot in list view.
+
+| # | Test Case | Steps | Expected Result |
+|---|-----------|-------|-----------------|
+| AC-1 | Set color on a single node | 1. Right-click a node 2. Set Color → Red | Red 3px bar appears on the node's left edge in graph view |
+| AC-2 | Clear color | 1. On a colored node, Set Color → No color | Bar disappears; node returns to default appearance |
+| AC-3 | Color persists in list view | 1. Color a node red 2. Switch to list view | Red dot next to title |
+| AC-4 | Batch color via multi-select | 1. Select 3+ nodes (Shift-click) 2. Right-click → Set Color → Blue | All selected nodes show blue bar; single undo reverts all |
+| AC-5 | Persist across reload | 1. Color a node, reload | Color still applied |
+| AC-6 | Undo restores previous color | 1. Color node red 2. Change to blue 3. Undo | Node is red again |
+| AC-7 | Touch: action sheet color picker | 1. Long-press a node on touch 2. Set Color → Green | Green accent applied |

--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -11,6 +11,7 @@ import ReactFlow, {
     ReactFlowProvider,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
+import { clsx } from 'clsx';
 import { v4 as uuidv4 } from 'uuid';
 import { useWorkspaceStore } from '../../store/workspaceStore';
 import { ContainerNode } from '../Nodes/ContainerNode';
@@ -19,7 +20,9 @@ import { ContextMenu, MenuItem } from '../UI/ContextMenu';
 import { ConfirmModal } from '../UI/ConfirmModal';
 import { ActionSheet } from '../UI/ActionSheet';
 import { FloatingActionButton } from '../UI/FloatingActionButton';
-import { Trash2, Circle, Clock, CheckCircle2, Plus, Layers, MousePointerClick, Sparkles, Maximize2 } from 'lucide-react';
+import { Trash2, Circle, Clock, CheckCircle2, Plus, Layers, MousePointerClick, Sparkles, Maximize2, Palette, Ban } from 'lucide-react';
+import { ACCENT_COLORS, ACCENT_BAR, ACCENT_LABEL } from '../../utils/accent';
+import type { AccentColor } from '../../types';
 import { useDeviceDetect } from '../../hooks/useDeviceDetect';
 import { isNodeActionable } from '../../utils/logic';
 import { StepDetailPanel } from '../ExecutionPanel/StepDetailPanel';
@@ -48,6 +51,7 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
     const addEdge = useWorkspaceStore(state => state.addEdge);
     const addNode = useWorkspaceStore(state => state.addNode);
     const batchUpdateNodes = useWorkspaceStore(state => state.batchUpdateNodes);
+    const setNodeColor = useWorkspaceStore(state => state.setNodeColor);
     const batchUpdatePositions = useWorkspaceStore(state => state.batchUpdatePositions);
     const selectMode = useWorkspaceStore(state => state.selectMode);
     const setHasSelection = useWorkspaceStore(state => state.setHasSelection);
@@ -657,6 +661,18 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
             }];
         }
 
+        const colorSwatch = (c: AccentColor) => (
+            <span className={clsx("inline-block w-3 h-3 rounded-full", ACCENT_BAR[c])} aria-hidden="true" />
+        );
+        const colorSubmenuFor = (apply: (c: AccentColor | null) => void): MenuItem[] => [
+            { label: 'No color', icon: <Ban className="w-4 h-4" />, onClick: () => apply(null) },
+            ...ACCENT_COLORS.map(c => ({
+                label: ACCENT_LABEL[c],
+                icon: colorSwatch(c),
+                onClick: () => apply(c),
+            })),
+        ];
+
         if (target.nodeId) {
             // Multi-select handling (desktop context menu only)
             if (opts?.multiSelect) {
@@ -670,6 +686,14 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
                             { label: 'In Progress', icon: <Clock className="w-4 h-4" />, onClick: () => batchUpdateNodes(nodeIds, { status: 'in_progress' }) },
                             { label: 'Done', icon: <CheckCircle2 className="w-4 h-4" />, onClick: () => batchUpdateNodes(nodeIds, { status: 'done' }) },
                         ],
+                        onClick: () => {},
+                    },
+                    {
+                        label: `Set Color (${selectedNodes.length} nodes)`,
+                        icon: <Palette className="w-4 h-4" />,
+                        submenu: colorSubmenuFor((c) => {
+                            nodeIds.forEach(id => setNodeColor(id, c));
+                        }),
                         onClick: () => {},
                     },
                     {
@@ -701,6 +725,12 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
                     onClick: () => {},
                 });
             }
+            items.push({
+                label: 'Set Color',
+                icon: <Palette className="w-4 h-4" />,
+                submenu: colorSubmenuFor((c) => setNodeColor(target.nodeId!, c)),
+                onClick: () => {},
+            });
             items.push({
                 label: 'Delete',
                 icon: <Trash2 className="w-4 h-4" />,
@@ -761,7 +791,7 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
                 },
             },
         ];
-    }, [activeGraphId, graph, reactFlowInstance, removeEdge, removeNode, removeNodes, updateNode, batchUpdateNodes, addNode, setAutoEditNodeId]);
+    }, [activeGraphId, graph, reactFlowInstance, removeEdge, removeNode, removeNodes, updateNode, batchUpdateNodes, setNodeColor, addNode, setAutoEditNodeId]);
 
     const buildActionSheetItems = useCallback((): MenuItem[] => {
         if (!actionSheet) return [];

--- a/src/components/ListView/ListView.tsx
+++ b/src/components/ListView/ListView.tsx
@@ -11,6 +11,18 @@ import { v4 as uuidv4 } from 'uuid';
 import { magicExpand, GeminiError } from '../../services/gemini';
 import { useToastStore } from '../UI/Toast';
 import { ConfirmModal } from '../UI/ConfirmModal';
+import { ACCENT_DOT } from '../../utils/accent';
+
+const AccentDot = ({ node }: { node: Node }) => {
+    const color = node.meta?.color;
+    if (!color) return null;
+    return (
+        <span
+            aria-hidden="true"
+            className={clsx('inline-block w-2 h-2 rounded-full flex-shrink-0', ACCENT_DOT[color])}
+        />
+    );
+};
 
 const StatusIcon = ({ status, blocked, size = 'sm' }: { status?: string; blocked?: boolean; size?: 'sm' | 'md' }) => {
     const cls = size === 'md' ? 'w-5 h-5' : 'w-4 h-4';
@@ -134,6 +146,8 @@ const ActionItem: React.FC<{ node: Node; blocked: boolean; depth: number; isPara
             >
                 <StatusIcon status={node.status} blocked={blocked} size="md" />
             </button>
+
+            <AccentDot node={node} />
 
             {editing ? (
                 <input
@@ -317,6 +331,8 @@ const ContainerItem: React.FC<{
                 )}
 
                 <Layers className="w-5 h-5 text-indigo-400 flex-shrink-0" />
+
+                <AccentDot node={node} />
 
                 <div className="flex-1 min-w-0">
                     {editing ? (

--- a/src/components/Nodes/ActionNode.tsx
+++ b/src/components/Nodes/ActionNode.tsx
@@ -8,6 +8,7 @@ import { clsx } from 'clsx';
 import { useWorkspaceStore } from '../../store/workspaceStore';
 import { isNodeBlocked, isNodeActionable } from '../../utils/logic';
 import { useDeviceDetect } from '../../hooks/useDeviceDetect';
+import { ACCENT_BAR } from '../../utils/accent';
 
 const MIN_WIDTH = 140;
 const MAX_WIDTH = 500;
@@ -154,6 +155,16 @@ export const ActionNode = memo(({ data, selected }: NodeProps<Node>) => {
             </NodeResizeControl>
 
             <Handle type="target" position={Position.Left} className="!w-3 !h-3 !bg-slate-400 !top-1/2 !-translate-y-1/2" />
+
+            {data.meta?.color && (
+                <div
+                    aria-hidden="true"
+                    className={clsx(
+                        "absolute left-0 top-0 bottom-0 w-[3px] rounded-l-lg",
+                        ACCENT_BAR[data.meta.color]
+                    )}
+                />
+            )}
 
             <div className="flex items-start gap-2">
                 <button

--- a/src/components/Nodes/ContainerNode.tsx
+++ b/src/components/Nodes/ContainerNode.tsx
@@ -12,6 +12,7 @@ import { getContainerProgress, isNodeBlocked } from '../../utils/logic';
 import { magicExpand, GeminiError } from '../../services/gemini';
 import { ConfirmModal } from '../UI/ConfirmModal';
 import { useDeviceDetect } from '../../hooks/useDeviceDetect';
+import { ACCENT_BAR } from '../../utils/accent';
 
 const WIDTH = 200;
 const HEIGHT = 80;
@@ -277,6 +278,16 @@ export const ContainerNode = memo(({ data, selected }: NodeProps<SpatialNode>) =
             </NodeResizeControl>
 
             <Handle type="target" position={Position.Left} className="!w-3 !h-3 !bg-indigo-400 !top-1/2 !-translate-y-1/2" />
+
+            {data.meta?.color && (
+                <div
+                    aria-hidden="true"
+                    className={clsx(
+                        "absolute left-0 top-0 bottom-0 w-[3px] rounded-l-lg",
+                        ACCENT_BAR[data.meta.color]
+                    )}
+                />
+            )}
 
             <div className="flex flex-col gap-2">
                 <div className="flex items-start justify-between border-b border-indigo-800 pb-2 mb-1">

--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { temporal } from 'zundo';
 import { v4 as uuidv4 } from 'uuid';
-import { Workspace, Node, Graph, Edge, Project, WorkspaceSettings } from '../types';
+import { Workspace, Node, Graph, Edge, Project, WorkspaceSettings, AccentColor } from '../types';
 import { generateWorkspace } from '../utils/generator';
 import { saveGeminiConfig, loadGeminiConfig } from '../lib/workspaceSync';
 
@@ -69,6 +69,7 @@ interface WorkspaceState extends Workspace {
     // Graph edits
     addNode: (node: Node) => void;
     updateNode: (nodeId: string, data: Partial<Node>, graphId?: string) => void;
+    setNodeColor: (nodeId: string, color: AccentColor | null, graphId?: string) => void;
     removeNode: (nodeId: string, graphId?: string) => void;
     removeEdge: (edgeId: string) => void;
     removeNodes: (nodeIds: string[]) => void;
@@ -337,6 +338,24 @@ export const useWorkspaceStore = create<WorkspaceState>()(
                 if (!graph) return;
                 const updatedNodes = graph.nodes.map(n => n.id === nodeId ? { ...n, ...data } : n);
 
+                set({
+                    graphs: { ...graphs, [targetGraphId]: { ...graph, nodes: updatedNodes } }
+                });
+            },
+
+            setNodeColor: (nodeId, color, graphId?) => {
+                const { activeGraphId, graphs } = get();
+                const targetGraphId = graphId || activeGraphId;
+                if (!targetGraphId) return;
+
+                const graph = graphs[targetGraphId];
+                if (!graph) return;
+                const updatedNodes = graph.nodes.map(n => {
+                    if (n.id !== nodeId) return n;
+                    const { color: _drop, ...restMeta } = n.meta ?? {};
+                    const nextMeta = color ? { ...restMeta, color } : restMeta;
+                    return { ...n, meta: nextMeta };
+                });
                 set({
                     graphs: { ...graphs, [targetGraphId]: { ...graph, nodes: updatedNodes } }
                 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,12 +12,20 @@ export interface ImageAttachment {
     // hidden?: boolean;
 }
 
+/**
+ * Closed enum of accent colors for a node. Used purely for at-a-glance
+ * categorization — no semantic meaning, no filtering. Closed set (vs.
+ * arbitrary hex) keeps Tailwind's JIT happy and preserves theme compatibility.
+ */
+export type AccentColor = 'gray' | 'red' | 'amber' | 'green' | 'blue' | 'purple' | 'pink';
+
 export interface NodeMeta {
     notes?: string;
     tags?: string[];
     verification?: string;
     images?: ImageAttachment[];
     imagesOpen?: boolean; // persisted open/closed state of the Visual References section
+    color?: AccentColor;  // optional accent color shown as a left-edge bar and list dot
     [key: string]: any;
 }
 

--- a/src/utils/accent.ts
+++ b/src/utils/accent.ts
@@ -1,0 +1,46 @@
+import type { AccentColor } from '../types';
+
+/**
+ * Palette of accent colors available to nodes.
+ * Keep in sync with the `AccentColor` type in `src/types/index.ts`.
+ * Order here drives the picker layout.
+ */
+export const ACCENT_COLORS: AccentColor[] = ['gray', 'red', 'amber', 'green', 'blue', 'purple', 'pink'];
+
+/**
+ * Solid-fill Tailwind class for the 3px left-edge bar on nodes.
+ * Written as static strings so Tailwind's JIT keeps them.
+ */
+export const ACCENT_BAR: Record<AccentColor, string> = {
+    gray: 'bg-gray-400',
+    red: 'bg-red-500',
+    amber: 'bg-amber-500',
+    green: 'bg-emerald-500',
+    blue: 'bg-sky-500',
+    purple: 'bg-purple-500',
+    pink: 'bg-pink-500',
+};
+
+/**
+ * Solid-fill Tailwind class for the 8px list-view dot.
+ */
+export const ACCENT_DOT: Record<AccentColor, string> = {
+    gray: 'bg-gray-400',
+    red: 'bg-red-500',
+    amber: 'bg-amber-500',
+    green: 'bg-emerald-500',
+    blue: 'bg-sky-500',
+    purple: 'bg-purple-500',
+    pink: 'bg-pink-500',
+};
+
+/** Friendly label used by the picker for accessibility. */
+export const ACCENT_LABEL: Record<AccentColor, string> = {
+    gray: 'Gray',
+    red: 'Red',
+    amber: 'Amber',
+    green: 'Green',
+    blue: 'Blue',
+    purple: 'Purple',
+    pink: 'Pink',
+};


### PR DESCRIPTION
## Summary

- **Item 2 / Quick Win #4** from [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md)
- Each node can be tagged with one of 7 accent colors (gray, red, amber, green, blue, purple, pink) via context menu → Set Color. The accent renders as a 3px left-edge bar in graph view and as an 8px dot in list view.
- Purely visual categorization — **no semantic meaning**, no filtering, no dependency interaction.
- Available in both the single-node and multi-select context menus. Batch apply is a single undo step.

## Motivation

From FEATURE_OPPORTUNITIES.md Quick Win #4: "one field in `meta`, one swatch picker. Immediate visual expression boost; enables at-a-glance categorization without a tag system." Closed enum vs. arbitrary hex keeps Tailwind's JIT happy and preserves dark/light theme compatibility (prep for Item 3).

## Changes

- `src/types/index.ts` — `AccentColor` type + optional `color?: AccentColor` on `NodeMeta`.
- `src/utils/accent.ts` (new) — palette, ACCENT_BAR, ACCENT_DOT, ACCENT_LABEL maps.
- `src/store/workspaceStore.ts` — `setNodeColor(nodeId, color | null)` action (zundo-tracked).
- `src/components/Nodes/ActionNode.tsx` + `ContainerNode.tsx` — render 3px left-edge bar when `meta.color` is set.
- `src/components/ListView/ListView.tsx` — `AccentDot` next to title for both action and container rows.
- `src/components/Canvas/CanvasArea.tsx` — Set Color submenu in single + multi-select context menus (shared builder means the touch action sheet also gets it).
- Docs: EXPECTED_UI_BEHAVIORS §10a, QA guide AC-1..AC-7.

## Test plan

- [ ] Right-click a node → Set Color → Red applies a red left bar
- [ ] Set Color → No color clears the accent
- [ ] Switch to list view → red dot appears next to the same node
- [ ] Multi-select 3 nodes → Set Color → Blue applies to all
- [ ] Single undo reverts batch color change
- [ ] Color persists through reload
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
