### PR TITLE
Add keyboard shortcuts cheatsheet (? opens modal)

### DIFF
--- a/EXPECTED_UI_BEHAVIORS.md
+++ b/EXPECTED_UI_BEHAVIORS.md
@@ -205,6 +205,16 @@ All shortcuts should only fire when the canvas has focus (not when typing in an 
 
 ---
 
+## 10b. Keyboard Shortcuts Cheatsheet
+
+- Pressing `?` (Shift+/) anywhere outside an input or textarea opens a modal listing every user-facing keyboard shortcut, grouped by category.
+- A "Keyboard shortcuts" link at the bottom of the sidebar opens the same modal (discoverability for touch/mouse users).
+- Shortcut labels swap `Cmd`/`Ctrl` based on the user's platform.
+- Modal dismissal: `Esc`, click-outside, or the × button.
+- Source of truth: `src/utils/shortcuts.ts`. Contributors adding new shortcuts MUST update that list.
+
+---
+
 ## 11. Status Cycling
 
 - **Click the status icon** (left side of an action node) → cycles through: Todo → In Progress → Done → Todo.

--- a/SPATIAL_TASKS_QA_GUIDE.md
+++ b/SPATIAL_TASKS_QA_GUIDE.md
@@ -1321,3 +1321,18 @@ The following test cases verify fixes from the codebase audit (`SPATIAL_TASKS_CO
 | AF-13 | FlowGenerator loads on demand | 1. Click "Generate Flow" button | FlowGenerator chunk loads; modal opens correctly |
 | AF-14 | MarkdownImporter loads on demand | 1. Click "Import Plan" button | MarkdownImporter chunk loads; modal opens correctly |
 | AF-15 | Build produces multiple chunks | 1. Run `npm run build` | Output shows separate chunks for react-flow, supabase, and lazy-loaded modals |
+
+### Feature: Keyboard Shortcuts Cheatsheet
+
+**What changed:** Pressing `?` (Shift+/) opens a modal listing all user-facing keyboard shortcuts, grouped by category. Also accessible from the sidebar footer.
+
+| # | Test Case | Steps | Expected Result |
+|---|-----------|-------|-----------------|
+| KS-1 | Open via ? | 1. Focus the canvas 2. Press Shift+/ | Modal appears with 4 categories: Canvas, Selection, Edit, Focus View |
+| KS-2 | ? suppressed while typing | 1. Double-click a node to edit 2. Type "?" | No modal; character goes into input |
+| KS-3 | Close via Esc | 1. Open modal 2. Press Esc | Modal closes |
+| KS-4 | Close via click-outside | 1. Open modal 2. Click the dimmed backdrop | Modal closes |
+| KS-5 | Close via × button | 1. Open modal 2. Click × | Modal closes |
+| KS-6 | Open via sidebar | 1. Click "Keyboard shortcuts" in the sidebar footer | Modal opens |
+| KS-7 | Mac labels use ⌘ | On macOS, verify modifier labels show ⌘/⇧/⌥ | Keys render as macOS glyphs |
+| KS-8 | Windows labels use Ctrl | On Windows/Linux, verify labels use Ctrl/Shift/Alt | Keys render as Windows words |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { ListView } from './components/ListView/ListView';
 import { FocusView } from './components/FocusView/FocusView';
 import { ToastContainer } from './components/UI/Toast';
 import { LoadingScreen } from './components/UI/LoadingScreen';
+import { ShortcutsModal } from './components/UI/ShortcutsModal';
 import { useWorkspaceStore } from './store/workspaceStore';
 import { useWorkspaceSync } from './hooks/useWorkspaceSync';
 
@@ -26,6 +27,7 @@ function App() {
     const viewMode = useWorkspaceStore(state => state.viewMode);
     const [showFlowGenerator, setShowFlowGenerator] = useState(false);
     const [showMarkdownImporter, setShowMarkdownImporter] = useState(false);
+    const [showShortcuts, setShowShortcuts] = useState(false);
 
     useEffect(() => {
         if (!activeProjectId && projects.length > 0) {
@@ -33,13 +35,35 @@ function App() {
         }
     }, [activeProjectId, projects, loadProject]);
 
+    // Global ? handler to open the cheatsheet (disabled while typing in inputs).
+    useEffect(() => {
+        const handleKey = (e: KeyboardEvent) => {
+            if (e.key !== '?') return;
+            const active = document.activeElement as HTMLElement | null;
+            const isTyping = !!active && (
+                active.tagName === 'INPUT' ||
+                active.tagName === 'TEXTAREA' ||
+                active.isContentEditable
+            );
+            if (isTyping) return;
+            e.preventDefault();
+            setShowShortcuts(true);
+        };
+        document.addEventListener('keydown', handleKey);
+        return () => document.removeEventListener('keydown', handleKey);
+    }, []);
+
     if (!supabaseLoaded) {
         return <LoadingScreen message="Loading your workspace..." />;
     }
 
     return (
         <div className="flex w-screen h-screen overflow-hidden bg-black text-white font-sans selection:bg-purple-500/30" style={{ paddingTop: 'var(--sat, 0px)' }}>
-            <Sidebar onGenerateFlow={() => setShowFlowGenerator(true)} onImportPlan={() => setShowMarkdownImporter(true)} />
+            <Sidebar
+                onGenerateFlow={() => setShowFlowGenerator(true)}
+                onImportPlan={() => setShowMarkdownImporter(true)}
+                onShowShortcuts={() => setShowShortcuts(true)}
+            />
             <div className="flex-1 flex flex-col h-full overflow-hidden relative">
                 <TopBar />
                 {viewMode === 'list'
@@ -53,6 +77,7 @@ function App() {
                 {showFlowGenerator && <FlowGenerator open={showFlowGenerator} onClose={() => setShowFlowGenerator(false)} />}
                 {showMarkdownImporter && <MarkdownImporter open={showMarkdownImporter} onClose={() => setShowMarkdownImporter(false)} />}
             </Suspense>
+            {showShortcuts && <ShortcutsModal onClose={() => setShowShortcuts(false)} />}
         </div>
     );
 }

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -5,15 +5,16 @@ import { useToastStore } from '../UI/Toast';
 import { ConfirmModal } from '../UI/ConfirmModal';
 import { supabase } from '../../lib/supabase';
 import { clsx } from 'clsx';
-import { FolderGit2, RefreshCw, Settings, Eye, EyeOff, KeyRound, Trash2, ArrowLeft, ExternalLink, LogOut, User, Lock, Plus, Sparkles, FileUp } from 'lucide-react';
+import { FolderGit2, RefreshCw, Settings, Eye, EyeOff, KeyRound, Trash2, ArrowLeft, ExternalLink, LogOut, User, Lock, Plus, Sparkles, FileUp, Keyboard } from 'lucide-react';
 import { useDeviceDetect } from '../../hooks/useDeviceDetect';
 
 interface SidebarProps {
     onGenerateFlow?: () => void;
     onImportPlan?: () => void;
+    onShowShortcuts?: () => void;
 }
 
-export const Sidebar: React.FC<SidebarProps> = ({ onGenerateFlow, onImportPlan }) => {
+export const Sidebar: React.FC<SidebarProps> = ({ onGenerateFlow, onImportPlan, onShowShortcuts }) => {
     const { isMobile } = useDeviceDetect();
     const sidebarOpen = useWorkspaceStore(state => state.sidebarOpen);
     const closeSidebar = useWorkspaceStore(state => state.closeSidebar);
@@ -354,6 +355,16 @@ export const Sidebar: React.FC<SidebarProps> = ({ onGenerateFlow, onImportPlan }
                                 <User className="w-3 h-3 shrink-0" />
                                 <span className="truncate">{user.email}</span>
                             </div>
+                        )}
+                        {onShowShortcuts && (
+                            <button
+                                onClick={onShowShortcuts}
+                                className="flex items-center gap-2 text-xs text-gray-500 hover:text-gray-300 w-full px-2 py-2"
+                                title="Show keyboard shortcuts (?)"
+                            >
+                                <Keyboard className="w-3 h-3" />
+                                Keyboard shortcuts
+                            </button>
                         )}
                         <button
                             onClick={() => setShowResetConfirm(true)}

--- a/src/components/UI/ShortcutsModal.tsx
+++ b/src/components/UI/ShortcutsModal.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { X } from 'lucide-react';
+import { SHORTCUTS, SHORTCUT_CATEGORIES, isMac, keyLabel, Shortcut } from '../../utils/shortcuts';
+
+interface ShortcutsModalProps {
+    onClose: () => void;
+}
+
+/**
+ * Keyboard shortcut cheatsheet modal. Opened via ? or from the sidebar
+ * "Keyboard shortcuts" affordance. Groups shortcuts by category.
+ */
+export function ShortcutsModal({ onClose }: ShortcutsModalProps) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const mac = useMemo(isMac, []);
+
+    // Esc + click-outside + focus-trap-lite (focus the dialog when mounted).
+    useEffect(() => {
+        containerRef.current?.focus();
+        const handleKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                e.stopPropagation();
+                onClose();
+            }
+        };
+        document.addEventListener('keydown', handleKey, true);
+        return () => document.removeEventListener('keydown', handleKey, true);
+    }, [onClose]);
+
+    const grouped = useMemo(() => {
+        const out: Record<string, Shortcut[]> = {};
+        for (const cat of SHORTCUT_CATEGORIES) out[cat] = [];
+        for (const s of SHORTCUTS) out[s.category].push(s);
+        return out;
+    }, []);
+
+    return (
+        <div
+            className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-4"
+            onMouseDown={onClose}
+        >
+            <div
+                ref={containerRef}
+                tabIndex={-1}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Keyboard shortcuts"
+                className="bg-slate-900 border border-slate-700 rounded-xl shadow-2xl max-w-2xl w-full max-h-[85vh] overflow-hidden flex flex-col outline-none"
+                onMouseDown={e => e.stopPropagation()}
+            >
+                <div className="flex items-center justify-between px-5 py-4 border-b border-slate-800">
+                    <h2 className="text-base font-semibold text-slate-100">Keyboard shortcuts</h2>
+                    <button
+                        onClick={onClose}
+                        aria-label="Close"
+                        className="p-1.5 rounded-md text-slate-400 hover:text-slate-100 hover:bg-slate-800 min-h-[32px] min-w-[32px] flex items-center justify-center touch:min-h-[44px] touch:min-w-[44px]"
+                    >
+                        <X className="w-4 h-4" />
+                    </button>
+                </div>
+
+                <div className="overflow-y-auto px-5 py-4 grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-5">
+                    {SHORTCUT_CATEGORIES.map(cat => (
+                        <section key={cat}>
+                            <h3 className="text-[11px] uppercase tracking-wider font-semibold text-purple-300 mb-2">{cat}</h3>
+                            <ul className="flex flex-col gap-1.5">
+                                {grouped[cat].map((s, i) => (
+                                    <li key={i} className="flex items-center justify-between gap-3 text-sm">
+                                        <span className="text-slate-200">{s.description}</span>
+                                        <span className="flex items-center gap-1 flex-shrink-0">
+                                            {s.keys.map((k, ki) => (
+                                                <kbd
+                                                    key={ki}
+                                                    className="px-1.5 py-0.5 rounded border border-slate-700 bg-slate-800 text-[11px] font-mono text-slate-200 min-w-[20px] text-center"
+                                                >
+                                                    {keyLabel(k, mac)}
+                                                </kbd>
+                                            ))}
+                                        </span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </section>
+                    ))}
+                </div>
+
+                <div className="px-5 py-3 border-t border-slate-800 text-[11px] text-slate-500">
+                    Press <kbd className="px-1 py-0.5 rounded border border-slate-700 bg-slate-800 text-slate-300">Esc</kbd> to close.
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/utils/shortcuts.ts
+++ b/src/utils/shortcuts.ts
@@ -1,0 +1,59 @@
+export type ShortcutCategory = 'Canvas' | 'Selection' | 'Edit' | 'Focus View';
+
+export interface Shortcut {
+    /** Display-friendly keys. Use 'Cmd' on mac, handled at render time. */
+    keys: string[];
+    description: string;
+    category: ShortcutCategory;
+}
+
+/**
+ * Canonical list of user-facing keyboard shortcuts.
+ *
+ * IMPORTANT: When you add a new shortcut anywhere in the codebase,
+ * add it here too. This list drives the ? cheatsheet and is the
+ * single source of truth users see.
+ */
+export const SHORTCUTS: Shortcut[] = [
+    // Canvas
+    { keys: ['N'], description: 'New action task at viewport center', category: 'Canvas' },
+    { keys: ['G'], description: 'New container group at viewport center', category: 'Canvas' },
+    { keys: ['Double-click'], description: 'Add task at cursor position', category: 'Canvas' },
+    { keys: ['Cmd', 'Shift', 'F'], description: 'Fit view to all nodes', category: 'Canvas' },
+    { keys: ['Esc'], description: 'Dismiss menus / connect mode / deselect', category: 'Canvas' },
+
+    // Selection
+    { keys: ['Cmd', 'A'], description: 'Select all nodes', category: 'Selection' },
+    { keys: ['Shift', 'Click'], description: 'Add node to selection', category: 'Selection' },
+    { keys: ['Backspace'], description: 'Delete selected nodes/edges', category: 'Selection' },
+    { keys: ['Delete'], description: 'Delete selected nodes/edges', category: 'Selection' },
+    { keys: ['Arrow ←/→'], description: 'Navigate along edges', category: 'Selection' },
+    { keys: ['Arrow ↑/↓'], description: 'Navigate to parallel siblings', category: 'Selection' },
+
+    // Edit
+    { keys: ['Cmd', 'Z'], description: 'Undo', category: 'Edit' },
+    { keys: ['Cmd', 'Shift', 'Z'], description: 'Redo', category: 'Edit' },
+    { keys: ['?'], description: 'Show this cheatsheet', category: 'Edit' },
+
+    // Focus View
+    { keys: ['Space'], description: 'Cycle status of hero task', category: 'Focus View' },
+    { keys: ['Enter'], description: 'Cycle status of hero task', category: 'Focus View' },
+    { keys: ['←'], description: 'Previous task', category: 'Focus View' },
+    { keys: ['→'], description: 'Skip to next task', category: 'Focus View' },
+];
+
+export const SHORTCUT_CATEGORIES: ShortcutCategory[] = ['Canvas', 'Selection', 'Edit', 'Focus View'];
+
+/** True on platforms where Command is the primary modifier. */
+export function isMac(): boolean {
+    if (typeof navigator === 'undefined') return false;
+    return /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+}
+
+/** Display label for a single key, swapping Cmd/Ctrl based on platform. */
+export function keyLabel(key: string, mac: boolean): string {
+    if (key === 'Cmd') return mac ? '⌘' : 'Ctrl';
+    if (key === 'Shift') return mac ? '⇧' : 'Shift';
+    if (key === 'Alt') return mac ? '⌥' : 'Alt';
+    return key;
+}


### PR DESCRIPTION
## Summary

- **Item 4 / Quick Win #3** from [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md)
- Pressing `?` (Shift+/) anywhere outside an input opens a modal listing every user-facing keyboard shortcut grouped by category (Canvas, Selection, Edit, Focus View).
- Also discoverable from a "Keyboard shortcuts" link in the sidebar footer.
- Modifier labels swap between macOS (`⌘ ⇧ ⌥`) and Windows/Linux (`Ctrl Shift Alt`) at runtime.

## Motivation

Shortcuts existed — Cmd+Z, N, G, Arrow nav, Cmd+Shift+F, etc. — but they were invisible to users. This centralizes the list in one file (`src/utils/shortcuts.ts`) as a contributor source of truth and surfaces it via `?` and a sidebar affordance.

## Changes

- `src/utils/shortcuts.ts` (new) — `SHORTCUTS` list, `SHORTCUT_CATEGORIES`, `isMac()` + `keyLabel()` helpers.
- `src/components/UI/ShortcutsModal.tsx` (new) — dialog with Esc, click-outside, and × dismissal; focus-trap-lite.
- `src/App.tsx` — global `?` keydown handler (suppressed when typing into input/textarea/contentEditable).
- `src/components/Layout/Sidebar.tsx` — "Keyboard shortcuts" link in the footer, opens the modal.
- Docs: EXPECTED_UI_BEHAVIORS §10b, QA guide KS-1..KS-8.

## Test plan

- [ ] Press `?` on desktop → modal opens with 4 categories
- [ ] Type `?` in a node title editor → no modal (suppressed)
- [ ] Esc closes the modal
- [ ] Click-outside (on the backdrop) closes the modal
- [ ] × button closes the modal
- [ ] Sidebar "Keyboard shortcuts" link opens the modal
- [ ] On macOS, modifier keys show `⌘` / `⇧`
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
