### PR TITLE
Add cross-view selection sync (graph ↔ list)

### DIFF
--- a/EXPECTED_UI_BEHAVIORS.md
+++ b/EXPECTED_UI_BEHAVIORS.md
@@ -205,6 +205,18 @@ All shortcuts should only fire when the canvas has focus (not when typing in an 
 
 ---
 
+## 10c. Cross-View Selection Sync
+
+- A single "focused node" is tracked at the workspace level so selection survives graph ↔ list view switches.
+- **Graph → List**: select a node on the canvas, switch to list view → that row renders with a purple highlight ring; the list auto-scrolls it into view.
+- **List → Graph**: click a row in list view, switch to graph view → that node is pre-selected and the viewport auto-fits to it.
+- Multi-select remains view-local (only single-node focus syncs).
+- Clicking empty canvas or the empty list area clears the focused node.
+- Cross-graph focus is a no-op — the store tracks the originating `graphId` and only applies sync when the user is in the same graph.
+- The focused node is **transient**: not persisted across reloads.
+
+---
+
 ## 11. Status Cycling
 
 - **Click the status icon** (left side of an action node) → cycles through: Todo → In Progress → Done → Todo.

--- a/SPATIAL_TASKS_QA_GUIDE.md
+++ b/SPATIAL_TASKS_QA_GUIDE.md
@@ -1321,3 +1321,17 @@ The following test cases verify fixes from the codebase audit (`SPATIAL_TASKS_CO
 | AF-13 | FlowGenerator loads on demand | 1. Click "Generate Flow" button | FlowGenerator chunk loads; modal opens correctly |
 | AF-14 | MarkdownImporter loads on demand | 1. Click "Import Plan" button | MarkdownImporter chunk loads; modal opens correctly |
 | AF-15 | Build produces multiple chunks | 1. Run `npm run build` | Output shows separate chunks for react-flow, supabase, and lazy-loaded modals |
+
+### Feature: Cross-View Selection Sync
+
+**What changed:** Selecting a single node in graph view pre-selects it in list view, and vice versa. Multi-select is not synced.
+
+| # | Test Case | Steps | Expected Result |
+|---|-----------|-------|-----------------|
+| SS-1 | Graph → List (single node) | 1. Select a node on canvas 2. Switch to list view | That row has a purple ring; list scrolls it into view |
+| SS-2 | List → Graph | 1. Click a row in list view 2. Switch to graph view | That node is selected; viewport auto-frames it |
+| SS-3 | Multi-select NOT synced | 1. Shift-click 3 nodes on canvas 2. Switch to list view | No row is highlighted |
+| SS-4 | Deselect on empty canvas | 1. Select a node 2. Click empty canvas area 3. Switch to list view | No row is highlighted |
+| SS-5 | Deselect on empty list area | 1. Click a row 2. Click the empty list background 3. Switch to graph view | No node is pre-selected |
+| SS-6 | Cross-graph is no-op | 1. Select a node in root graph 2. Drill into a container 3. Observe | The container's canvas doesn't attempt to select the parent-graph node |
+| SS-7 | Not persisted | 1. Select a node 2. Reload | No node is selected on reload |

--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -56,6 +56,9 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
     const clearConnectMode = useWorkspaceStore(state => state.clearConnectMode);
     const setAutoEditNodeId = useWorkspaceStore(state => state.setAutoEditNodeId);
     const executionMode = useWorkspaceStore(state => state.executionMode);
+    const focusedNodeId = useWorkspaceStore(state => state.focusedNodeId);
+    const focusedNodeGraphId = useWorkspaceStore(state => state.focusedNodeGraphId);
+    const setFocusedNode = useWorkspaceStore(state => state.setFocusedNode);
 
     const reactFlowInstance = useReactFlow();
 
@@ -88,9 +91,17 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
 
     const graph = activeGraphId ? graphs[activeGraphId] : null;
 
-    // Transform to ReactFlow format
+    // Tracks whether we've seeded the initial selection from the workspace-focused node.
+    const seededFocusRef = useRef(false);
+
+    // Transform to ReactFlow format. On first render after mount, seed selection
+    // from the cross-view `focusedNodeId`; afterward, selection is owned by RF.
     const nodes: RFNode[] = useMemo(() => {
         if (!graph) return [];
+        const shouldSeed = !seededFocusRef.current
+            && !!focusedNodeId
+            && (!focusedNodeGraphId || focusedNodeGraphId === graph.id)
+            && graph.nodes.some(n => n.id === focusedNodeId);
         return graph.nodes.map(n => ({
             id: n.id,
             type: n.type,
@@ -98,7 +109,12 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
             data: { ...n, _isConnectSource: connectMode.sourceNodeId === n.id },
             draggable: !connectMode.active,
             style: { width: n.width ?? 200 },
+            selected: shouldSeed && n.id === focusedNodeId ? true : undefined,
         }));
+        // Intentional: we only want to re-compute when the graph or connect mode
+        // changes. focusedNodeId changes after the user interacts with the canvas
+        // and must NOT reset RF's internal selection.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [graph, connectMode]);
 
     const edges: RFEdge[] = useMemo(() => {
@@ -395,6 +411,26 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
         document.addEventListener('keydown', handleKeyDown);
         return () => document.removeEventListener('keydown', handleKeyDown);
     }, [deleteSelected, handleFitView, graph, reactFlowInstance, setHasSelection, createQuickNodeAtViewportCenter, connectMode.active, clearConnectMode, contextMenu, actionSheet, quickAdd]);
+
+    // On mount, after the initial seeded render, fit view to the focused node and
+    // lock out further seeding so RF owns selection from here on.
+    useEffect(() => {
+        if (seededFocusRef.current) return;
+        seededFocusRef.current = true;
+        if (!focusedNodeId) return;
+        if (!activeGraphId) return;
+        if (focusedNodeGraphId && focusedNodeGraphId !== activeGraphId) return;
+        const timer = window.setTimeout(() => {
+            const rfNodes = reactFlowInstance.getNodes();
+            const node = rfNodes.find(n => n.id === focusedNodeId);
+            if (!node) return;
+            setHasSelection(true);
+            reactFlowInstance.fitView({ nodes: [node], padding: 0.4, duration: 300, maxZoom: 1.5 });
+        }, 80);
+        return () => window.clearTimeout(timer);
+        // Runs exactly once on mount — see nodes memo above for the selection seeding.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     // Process canvas actions dispatched from other components via the store
     const pendingCanvasAction = useWorkspaceStore(state => state.pendingCanvasAction);
@@ -812,6 +848,12 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
                 onPaneContextMenu={handlePaneContextMenu}
                 onSelectionChange={({ nodes: selNodes, edges: selEdges }) => {
                     setHasSelection((selNodes?.length ?? 0) > 0 || (selEdges?.length ?? 0) > 0);
+                    // Cross-view focus sync: only track single-node selections (multi-select stays view-local).
+                    if (selNodes && selNodes.length === 1) {
+                        setFocusedNode(selNodes[0].id);
+                    } else if (!selNodes || selNodes.length === 0) {
+                        if (useWorkspaceStore.getState().focusedNodeId) setFocusedNode(null);
+                    }
                 }}
                 panOnDrag={isTouchDevice ? !selectMode : true}
                 selectionOnDrag={isTouchDevice ? selectMode : true}

--- a/src/components/ListView/ListView.tsx
+++ b/src/components/ListView/ListView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback } from 'react';
+import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { useWorkspaceStore } from '../../store/workspaceStore';
 import { Node, Graph } from '../../types';
 import { isNodeBlocked, getContainerProgress } from '../../utils/logic';
@@ -98,8 +98,21 @@ const ActionItem: React.FC<{ node: Node; blocked: boolean; depth: number; isPara
     const cycleNodeStatus = useWorkspaceStore(state => state.cycleNodeStatus);
     const updateNode = useWorkspaceStore(state => state.updateNode);
     const removeNode = useWorkspaceStore(state => state.removeNode);
+    const focusedNodeId = useWorkspaceStore(state => state.focusedNodeId);
+    const setFocusedNode = useWorkspaceStore(state => state.setFocusedNode);
     const [editing, setEditing] = useState(false);
     const [editValue, setEditValue] = useState(node.title);
+    const rowRef = useRef<HTMLDivElement>(null);
+    const isFocused = focusedNodeId === node.id;
+
+    // On mount (list view entered), scroll the focused row into view.
+    useEffect(() => {
+        if (isFocused && rowRef.current) {
+            rowRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        }
+        // Intentionally only run once per mount — switching focused node afterward shouldn't hijack scroll.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const handleStatusClick = useCallback(() => {
         if (blocked) return;
@@ -115,10 +128,17 @@ const ActionItem: React.FC<{ node: Node; blocked: boolean; depth: number; isPara
 
     return (
         <div
+            ref={rowRef}
+            onClick={(e) => {
+                // Don't steal focus when clicking buttons inside the row.
+                if ((e.target as HTMLElement).closest('button')) return;
+                setFocusedNode(node.id, graphId);
+            }}
             className={clsx(
-                'flex items-center gap-3 px-4 py-3 rounded-lg border transition-colors',
+                'flex items-center gap-3 px-4 py-3 rounded-lg border transition-colors cursor-pointer',
                 blocked ? 'bg-slate-900/50 border-slate-800 opacity-70' : 'bg-slate-800/50 border-slate-700/50 hover:border-slate-600',
                 node.status === 'done' && 'opacity-60',
+                isFocused && 'ring-2 ring-purple-500/60 border-purple-500/60',
             )}
             style={{ marginLeft: depth * 24 }}
         >
@@ -572,8 +592,16 @@ export const ListView: React.FC = () => {
     const totalActions = graph.nodes.filter(n => n.type === 'action').length;
 
     return (
-        <div className="flex-1 h-full bg-gray-950 overflow-y-auto">
-            <div className="max-w-2xl mx-auto px-4 py-6 space-y-3">
+        <div
+            className="flex-1 h-full bg-gray-950 overflow-y-auto"
+            onClick={(e) => {
+                // Click on empty list area (not a task row) clears focused node.
+                if (e.target === e.currentTarget || (e.target as HTMLElement).classList.contains('list-view-scroller')) {
+                    useWorkspaceStore.getState().setFocusedNode(null);
+                }
+            }}
+        >
+            <div className="max-w-2xl mx-auto px-4 py-6 space-y-3 list-view-scroller">
                 {/* Summary header */}
                 {totalActions > 0 && (
                     <div className="flex items-center justify-between px-2 pb-2 border-b border-gray-800">

--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -23,6 +23,11 @@ interface WorkspaceState extends Workspace {
     sidebarOpen: boolean;
     viewMode: 'graph' | 'list' | 'focus';
 
+    // Cross-view selection sync (transient — not persisted). Holds at most one node
+    // at a time. Cleared when the user clicks empty canvas / empty list area.
+    focusedNodeId: string | null;
+    focusedNodeGraphId: string | null;
+
     // Focus view session state (transient)
     focusNodeId: string | null;
     focusContextGraphId: string | null;
@@ -43,6 +48,7 @@ interface WorkspaceState extends Workspace {
     setConnectSource: (nodeId: string) => void;
     clearConnectMode: () => void;
     setAutoEditNodeId: (nodeId: string | null) => void;
+    setFocusedNode: (nodeId: string | null, graphId?: string | null) => void;
     toggleSidebar: () => void;
     closeSidebar: () => void;
     setViewMode: (mode: 'graph' | 'list' | 'focus') => void;
@@ -104,6 +110,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             autoEditNodeId: null,
             sidebarOpen: false,
             viewMode: 'graph' as const,
+            focusedNodeId: null,
+            focusedNodeGraphId: null,
             focusNodeId: null,
             focusContextGraphId: null,
             syncStatus: 'idle' as SyncStatus,
@@ -137,6 +145,14 @@ export const useWorkspaceStore = create<WorkspaceState>()(
 
             setAutoEditNodeId: (nodeId: string | null) => {
                 set({ autoEditNodeId: nodeId });
+            },
+
+            setFocusedNode: (nodeId, graphId) => {
+                const { activeGraphId } = get();
+                set({
+                    focusedNodeId: nodeId,
+                    focusedNodeGraphId: nodeId ? (graphId ?? activeGraphId ?? null) : null,
+                });
             },
 
             toggleSidebar: () => {
@@ -622,7 +638,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             storage: createJSONStorage(() => localStorage),
             partialize: (state) => {
                 // Exclude transient flags and actions from localStorage
-                const { _hydrated, _supabaseLoaded, selectMode, _hasSelection, connectMode, autoEditNodeId, sidebarOpen, viewMode, focusNodeId, focusContextGraphId, syncStatus, syncError, lastSavedAt, pendingCanvasAction, ...rest } = state;
+                const { _hydrated, _supabaseLoaded, selectMode, _hasSelection, connectMode, autoEditNodeId, sidebarOpen, viewMode, focusNodeId, focusContextGraphId, focusedNodeId, focusedNodeGraphId, syncStatus, syncError, lastSavedAt, pendingCanvasAction, ...rest } = state;
                 return rest;
             },
             onRehydrateStorage: () => {


### PR DESCRIPTION
## Summary

- **Item 6 / Quick Win #8** from [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md)
- Selecting a single node in graph view now pre-selects its matching row in list view (and scrolls it into view), and clicking a row in list view pre-selects the node when switching back to graph.
- Multi-select stays view-local. Clicking empty canvas / empty list area clears the focused node. Cross-graph focus is a no-op.

## Motivation

The three views (graph, list, focus) are "same data, different lens", but selection was lost at every switch. A small amount of shared transient state reinforces that mental model. No new persisted state — `focusedNodeId` is excluded from localStorage/Supabase.

## Changes

- `src/store/workspaceStore.ts` — `focusedNodeId` + `focusedNodeGraphId` transient state + `setFocusedNode(nodeId, graphId?)` action. NOT zundo-tracked.
- `src/components/Canvas/CanvasArea.tsx` — writes single selection to the store via `onSelectionChange`; seeds initial selection via the `nodes` memo (using a `seededFocusRef` so we don't fight the user) and `fitView`s to it on mount.
- `src/components/ListView/ListView.tsx` — action rows highlight when focused (purple ring), scroll into view on mount, and call `setFocusedNode` on click. Empty-area click clears focus.
- Docs: EXPECTED_UI_BEHAVIORS §10c, QA guide SS-1..SS-7.

## Test plan

- [ ] Select a node on canvas → switch to list → that row has a purple ring
- [ ] Click a row in list view → switch to graph → node is selected + framed
- [ ] Shift-click 3 nodes → switch to list → no highlight (multi-select not synced)
- [ ] Click empty list background → no row highlighted on return to graph
- [ ] Drill into a container after selecting a root-graph node → no cross-graph selection attempted
- [ ] Reload → no node selected (transient state)
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
