### PR TITLE
Add empty-canvas onboarding with ghost nodes

### DIFF
--- a/EXPECTED_UI_BEHAVIORS.md
+++ b/EXPECTED_UI_BEHAVIORS.md
@@ -223,6 +223,16 @@ All shortcuts should only fire when the canvas has focus (not when typing in an 
 
 ---
 
+## 10d. Empty-Canvas Onboarding
+
+- A brand-new user opening an empty root graph sees a rich onboarding overlay: three semi-transparent "ghost" nodes with dashed borders connected by dashed arrows, a call-to-action, shortcut hints, and a "Generate Flow with AI" button.
+- A **Skip** link in the top-right dismisses the overlay permanently.
+- Adding any node (via double-click, `N`, `G`, FAB, right-click menu, or any other path) also permanently dismisses the overlay.
+- Persisted via `settings.hasSeenOnboarding` in Zustand `persist` — the overlay never returns once dismissed, even if the canvas becomes empty again later.
+- The full onboarding is only shown in the **root** graph (`navStack.length === 1`). Empty container child graphs fall back to the subtler empty-state hint.
+
+---
+
 ## 11. Status Cycling
 
 - **Click the status icon** (left side of an action node) → cycles through: Todo → In Progress → Done → Todo.

--- a/SPATIAL_TASKS_QA_GUIDE.md
+++ b/SPATIAL_TASKS_QA_GUIDE.md
@@ -1365,3 +1365,16 @@ The following test cases verify fixes from the codebase audit (`SPATIAL_TASKS_CO
 | PT-8 | Touch: bottom sheet instead of chip bar | 1. On mobile/touch device, tap the "Blocked" badge on a blocked node | Bottom sheet slides up listing blockers with ≥44px tap targets |
 | PT-9 | Blocked state stays blocked after predecessor partial complete | 1. Mark some (not all) leaves of a container predecessor done 2. Click downstream node's blocker | Chip still lists the container with updated percentage |
 | PT-10 | Unblocked nodes show no badge | 1. Mark all predecessors done on a previously-blocked node | "Blocked" badge and lock icon disappear; status cycling works again |
+
+### Feature: Empty-Canvas Onboarding
+
+**What changed:** A brand-new user opening an empty root graph now sees ghost nodes, a CTA, shortcut hints, and a "Generate Flow with AI" option. Dismisses on Skip or on first node add.
+
+| # | Test Case | Steps | Expected Result |
+|---|-----------|-------|-----------------|
+| OB-1 | First-time user sees onboarding | 1. Clear localStorage 2. Create a new empty project | Ghost-node overlay + CTA + shortcut hints |
+| OB-2 | Skip persists | 1. Click Skip 2. Reload | No onboarding overlay |
+| OB-3 | Add-node dismisses | 1. On empty canvas, press N to add a task 2. Delete it | Onboarding does NOT return |
+| OB-4 | Empty container falls back | 1. Create a container on the root graph 2. Drill into it | The subtle empty-state hint appears, not the full onboarding |
+| OB-5 | AI CTA opens generator | 1. Click "Or: Generate Flow with AI" | FlowGenerator modal opens |
+| OB-6 | Touch variant | 1. On a touch device with empty root graph | Copy reads "Tap the + button to add your first task" |

--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -20,13 +20,14 @@ import { ContextMenu, MenuItem } from '../UI/ContextMenu';
 import { ConfirmModal } from '../UI/ConfirmModal';
 import { ActionSheet } from '../UI/ActionSheet';
 import { FloatingActionButton } from '../UI/FloatingActionButton';
-import { Trash2, Circle, Clock, CheckCircle2, Plus, Layers, MousePointerClick, Sparkles, Maximize2, Palette, Ban } from 'lucide-react';
+import { Trash2, Circle, Clock, CheckCircle2, Plus, Layers, MousePointerClick, Maximize2, Palette, Ban } from 'lucide-react';
 import { ACCENT_COLORS, ACCENT_BAR, ACCENT_LABEL } from '../../utils/accent';
 import type { AccentColor } from '../../types';
 import { useDeviceDetect } from '../../hooks/useDeviceDetect';
 import { isNodeActionable, getBlockingNodes, BlockingNodeInfo } from '../../utils/logic';
 import { StepDetailPanel } from '../ExecutionPanel/StepDetailPanel';
 import { BlockedSpotlight, useBlockingTitles } from './BlockedSpotlight';
+import { EmptyCanvasOnboarding } from './EmptyCanvasOnboarding';
 
 const nodeTypes = {
     container: ContainerNode,
@@ -61,6 +62,8 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
     const clearConnectMode = useWorkspaceStore(state => state.clearConnectMode);
     const setAutoEditNodeId = useWorkspaceStore(state => state.setAutoEditNodeId);
     const executionMode = useWorkspaceStore(state => state.executionMode);
+    const settings = useWorkspaceStore(state => state.settings);
+    const updateSettings = useWorkspaceStore(state => state.updateSettings);
 
     const reactFlowInstance = useReactFlow();
 
@@ -914,8 +917,17 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
                 )}
             </ReactFlow>
 
-            {/* Empty state guidance */}
-            {graph.nodes.length === 0 && !quickAdd && (
+            {/* Rich onboarding for brand-new users on an empty root graph. */}
+            {graph.nodes.length === 0 && !quickAdd && !settings.hasSeenOnboarding && navStack.length === 1 && (
+                <EmptyCanvasOnboarding
+                    isTouchDevice={isTouchDevice}
+                    onGenerateFlow={onGenerateFlow}
+                    onSkip={() => updateSettings({ hasSeenOnboarding: true })}
+                />
+            )}
+
+            {/* Subtler empty-state hint for everyone else (returning user, empty container, etc.). */}
+            {graph.nodes.length === 0 && !quickAdd && (settings.hasSeenOnboarding || navStack.length > 1) && (
                 <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
                     <div className="text-center space-y-3 max-w-xs">
                         <MousePointerClick className="w-10 h-10 text-gray-600 mx-auto" />
@@ -927,20 +939,6 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
                                 ? 'Or long-press the canvas for more options'
                                 : 'Or right-click for more options like creating containers'}
                         </p>
-                        {!isTouchDevice && (
-                            <p className="text-gray-600 text-[11px]">
-                                Shortcuts: <kbd className="px-1 py-0.5 rounded bg-gray-800 border border-gray-700">N</kbd> task, <kbd className="px-1 py-0.5 rounded bg-gray-800 border border-gray-700">G</kbd> group, <kbd className="px-1 py-0.5 rounded bg-gray-800 border border-gray-700">Esc</kbd> clear
-                            </p>
-                        )}
-                        {onGenerateFlow && (
-                            <button
-                                onClick={onGenerateFlow}
-                                className="pointer-events-auto inline-flex items-center gap-2 px-4 py-2.5 mt-2 rounded-lg text-sm font-medium bg-purple-600/20 border border-purple-700/50 text-purple-300 hover:bg-purple-600/30 hover:text-purple-200 transition-colors"
-                            >
-                                <Sparkles className="w-4 h-4" />
-                                Generate Flow with AI
-                            </button>
-                        )}
                     </div>
                 </div>
             )}

--- a/src/components/Canvas/EmptyCanvasOnboarding.tsx
+++ b/src/components/Canvas/EmptyCanvasOnboarding.tsx
@@ -1,0 +1,85 @@
+import { MousePointerClick, Sparkles, X } from 'lucide-react';
+
+interface EmptyCanvasOnboardingProps {
+    isTouchDevice: boolean;
+    onGenerateFlow?: () => void;
+    onSkip: () => void;
+}
+
+/**
+ * Empty-state onboarding overlay for a brand-new canvas.
+ * Renders ghost nodes + an arrow to teach the user where to start.
+ * Dismissed by adding a node or by clicking Skip (see CanvasArea).
+ */
+export function EmptyCanvasOnboarding({ isTouchDevice, onGenerateFlow, onSkip }: EmptyCanvasOnboardingProps) {
+    return (
+        <div className="absolute inset-0 pointer-events-none z-10 flex items-center justify-center">
+            {/* Ghost nodes — purely decorative, no ReactFlow interaction. */}
+            <div className="relative w-full max-w-2xl">
+                <div className="flex items-center justify-center gap-6 opacity-40 select-none">
+                    <GhostNode label="First task" animated />
+                    <GhostArrow />
+                    <GhostNode label="Next step" />
+                    <GhostArrow />
+                    <GhostNode label="Done" tone="done" />
+                </div>
+
+                {/* Central call-to-action */}
+                <div className="mt-10 text-center space-y-3">
+                    <MousePointerClick className="w-10 h-10 text-gray-500 mx-auto" />
+                    <p className="text-gray-300 text-sm font-medium">
+                        {isTouchDevice ? 'Tap the + button to add your first task' : 'Double-click anywhere to add your first task'}
+                    </p>
+                    {!isTouchDevice && (
+                        <p className="text-gray-500 text-[11px]">
+                            Shortcuts:{' '}
+                            <kbd className="px-1 py-0.5 rounded bg-gray-800 border border-gray-700">N</kbd> task,{' '}
+                            <kbd className="px-1 py-0.5 rounded bg-gray-800 border border-gray-700">G</kbd> group,{' '}
+                            <kbd className="px-1 py-0.5 rounded bg-gray-800 border border-gray-700">?</kbd> all shortcuts
+                        </p>
+                    )}
+                    {onGenerateFlow && (
+                        <button
+                            onClick={onGenerateFlow}
+                            className="pointer-events-auto inline-flex items-center gap-2 px-4 py-2.5 mt-2 rounded-lg text-sm font-medium bg-purple-600/20 border border-purple-700/50 text-purple-300 hover:bg-purple-600/30 hover:text-purple-200 transition-colors touch:min-h-[44px]"
+                        >
+                            <Sparkles className="w-4 h-4" />
+                            Or: Generate Flow with AI
+                        </button>
+                    )}
+                </div>
+            </div>
+
+            {/* Skip link — top-right of the canvas area */}
+            <button
+                onClick={onSkip}
+                className="pointer-events-auto absolute top-4 right-4 inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md text-xs text-gray-500 hover:text-gray-200 hover:bg-gray-800 transition-colors touch:min-h-[40px]"
+                aria-label="Dismiss onboarding hint"
+            >
+                Skip
+                <X className="w-3 h-3" />
+            </button>
+        </div>
+    );
+}
+
+function GhostNode({ label, tone, animated }: { label: string; tone?: 'done'; animated?: boolean }) {
+    const bg = tone === 'done' ? 'bg-slate-800/60' : 'bg-slate-700/60';
+    return (
+        <div
+            className={`px-4 py-2.5 rounded-lg border-2 border-dashed border-slate-600 ${bg} min-w-[120px] text-center ${animated ? 'animate-pulse' : ''}`}
+            aria-hidden="true"
+        >
+            <span className="text-[11px] text-slate-300 font-medium">{label}</span>
+        </div>
+    );
+}
+
+function GhostArrow() {
+    return (
+        <svg width="40" height="16" viewBox="0 0 40 16" className="text-slate-600" aria-hidden="true">
+            <line x1="0" y1="8" x2="32" y2="8" stroke="currentColor" strokeWidth="2" strokeDasharray="4 3" />
+            <path d="M 32 3 L 38 8 L 32 13" stroke="currentColor" strokeWidth="2" fill="none" />
+        </svg>
+    );
+}

--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -320,14 +320,20 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             },
 
             addNode: (node) => {
-                const { activeGraphId, graphs } = get();
+                const { activeGraphId, graphs, settings } = get();
                 if (!activeGraphId) return;
 
                 const graph = graphs[activeGraphId];
                 const updatedGraph = { ...graph, nodes: [...graph.nodes, node] };
 
+                // First node ever = dismiss the onboarding overlay permanently.
+                const patch: Partial<typeof settings> = settings.hasSeenOnboarding
+                    ? {}
+                    : { hasSeenOnboarding: true };
+
                 set({
-                    graphs: { ...graphs, [activeGraphId]: updatedGraph }
+                    graphs: { ...graphs, [activeGraphId]: updatedGraph },
+                    ...(Object.keys(patch).length ? { settings: { ...settings, ...patch } } : {}),
                 });
             },
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -108,6 +108,8 @@ export interface WorkspaceSettings {
     theme?: 'dark' | 'light';
     geminiApiKey?: string;
     geminiStatus?: GeminiConnectionStatus;
+    /** Once a user has seen (or dismissed) the empty-canvas onboarding, never show it again. */
+    hasSeenOnboarding?: boolean;
     [key: string]: any;
 }
 


### PR DESCRIPTION
## Summary

- **Item 5 / Quick Win #6** from [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md)
- Brand-new users on an empty root graph now see ghost nodes + CTA + shortcut hints + Generate-with-AI option.
- Dismisses on **Skip** or on **adding the first node** — never returns.
- Only shown in the root graph (`navStack.length === 1`). Empty subgraphs keep the subtle existing hint.

## Motivation

From FEATURE_OPPORTUNITIES.md Quick Win #6: "Most users bounce at the empty canvas." The previous empty-state was a single icon + one line. This gives three concrete paths forward (double-click, `N`, or AI) plus a preview of what a finished flow looks like.

## Changes

- `src/types/index.ts` — `settings.hasSeenOnboarding?: boolean`.
- `src/components/Canvas/EmptyCanvasOnboarding.tsx` (new) — ghost nodes + CTA + Skip.
- `src/components/Canvas/CanvasArea.tsx` — renders the new onboarding when `nodes.length === 0 && !settings.hasSeenOnboarding && navStack.length === 1`; keeps the subtle hint for all other empty states.
- `src/store/workspaceStore.ts` — `addNode` sets `hasSeenOnboarding: true` on first-ever call.
- Docs: EXPECTED_UI_BEHAVIORS §10d, QA guide OB-1..OB-6.

## Test plan

- [ ] Fresh localStorage + new project → onboarding overlay appears
- [ ] Skip button → overlay gone + subtle hint replaces it
- [ ] Press `N` to add a node → overlay gone permanently (even after deleting all nodes)
- [ ] Reload → still no overlay (flag persisted)
- [ ] Drill into empty container → subtle hint, not full onboarding
- [ ] "Generate Flow with AI" button → FlowGenerator opens
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
