### PR TITLE
Add theme toggle (dark default / light opt-in)

### DIFF
--- a/EXPECTED_UI_BEHAVIORS.md
+++ b/EXPECTED_UI_BEHAVIORS.md
@@ -223,6 +223,17 @@ All shortcuts should only fire when the canvas has focus (not when typing in an 
 
 ---
 
+## 10e. Theming (Dark / Light)
+
+- The app ships **dark theme by default**; users can switch to light via the sidebar footer toggle (sun/moon icon + "Light theme" / "Dark theme" label).
+- Theme is stored on `settings.theme` (`'dark' | 'light'`) and persists through `persist` + Supabase sync.
+- The theme is applied as `data-theme="light"` on the `<html>` element. Dark is the absence of that attribute.
+- Surface tokens (`--bg-canvas`, `--bg-panel`, `--text-primary`, `--border-default`, etc.) drive the palette; Tailwind utility classes like `bg-gray-900`, `text-slate-200`, `border-gray-700` are overridden via CSS variables when `[data-theme="light"]` is active.
+- Semantic colors (red for blocked, amber for execution-mode highlights, accent palette) are NOT remapped — only neutral surfaces are themed.
+- ReactFlow background dots and control buttons also respect the theme.
+
+---
+
 ## 11. Status Cycling
 
 - **Click the status icon** (left side of an action node) → cycles through: Todo → In Progress → Done → Todo.

--- a/SPATIAL_TASKS_QA_GUIDE.md
+++ b/SPATIAL_TASKS_QA_GUIDE.md
@@ -1365,3 +1365,18 @@ The following test cases verify fixes from the codebase audit (`SPATIAL_TASKS_CO
 | PT-8 | Touch: bottom sheet instead of chip bar | 1. On mobile/touch device, tap the "Blocked" badge on a blocked node | Bottom sheet slides up listing blockers with ≥44px tap targets |
 | PT-9 | Blocked state stays blocked after predecessor partial complete | 1. Mark some (not all) leaves of a container predecessor done 2. Click downstream node's blocker | Chip still lists the container with updated percentage |
 | PT-10 | Unblocked nodes show no badge | 1. Mark all predecessors done on a previously-blocked node | "Blocked" badge and lock icon disappear; status cycling works again |
+
+### Feature: Theme Toggle (Dark / Light)
+
+**What changed:** A sidebar toggle switches between dark (default) and light themes. Surface colors (backgrounds, borders, text) are themed; semantic colors (red, amber, accents) are not.
+
+| # | Test Case | Steps | Expected Result |
+|---|-----------|-------|-----------------|
+| TH-1 | Default is dark | 1. Fresh localStorage 2. Load app | Canvas, sidebar, top bar are dark |
+| TH-2 | Toggle to light | 1. Click "Light theme" in sidebar | Canvas becomes light gray, sidebar white, text dark |
+| TH-3 | Toggle back to dark | 1. Click "Dark theme" | Reverts to dark palette |
+| TH-4 | Theme persists across reload | 1. Set light 2. Reload | Still light |
+| TH-5 | ReactFlow dots re-theme | 1. Toggle to light | Background dots become lighter gray |
+| TH-6 | ReactFlow controls re-theme | 1. Toggle to light | +/−/fit/lock buttons have light background |
+| TH-7 | Semantic colors preserved | 1. Put a blocked node on canvas 2. Toggle light | Red "Blocked" badge remains red |
+| TH-8 | Accent colors preserved | 1. Color a node red 2. Toggle light | Red accent bar still visible |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,12 @@ function App() {
     const projects = useWorkspaceStore(state => state.projects);
     const loadProject = useWorkspaceStore(state => state.loadProject);
     const viewMode = useWorkspaceStore(state => state.viewMode);
+    const theme = useWorkspaceStore(state => state.settings.theme ?? 'dark');
+
+    // Apply theme at the document root so CSS variable overrides kick in.
+    useEffect(() => {
+        document.documentElement.dataset.theme = theme;
+    }, [theme]);
     const [showFlowGenerator, setShowFlowGenerator] = useState(false);
     const [showMarkdownImporter, setShowMarkdownImporter] = useState(false);
     const [showShortcuts, setShowShortcuts] = useState(false);

--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -897,7 +897,7 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
                 fitView
                 className="bg-gray-950"
             >
-                <Background color="#374151" gap={20} />
+                <Background color="var(--bg-dot)" gap={20} />
                 {!isTouchDevice && <Controls className="bg-gray-800 border-gray-700 fill-gray-100" />}
                 {!isTouchDevice && (
                     <MiniMap

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -5,7 +5,7 @@ import { useToastStore } from '../UI/Toast';
 import { ConfirmModal } from '../UI/ConfirmModal';
 import { supabase } from '../../lib/supabase';
 import { clsx } from 'clsx';
-import { FolderGit2, RefreshCw, Settings, Eye, EyeOff, KeyRound, Trash2, ArrowLeft, ExternalLink, LogOut, User, Lock, Plus, Sparkles, FileUp, Keyboard } from 'lucide-react';
+import { FolderGit2, RefreshCw, Settings, Eye, EyeOff, KeyRound, Trash2, ArrowLeft, ExternalLink, LogOut, User, Lock, Plus, Sparkles, FileUp, Keyboard, Sun, Moon } from 'lucide-react';
 import { useDeviceDetect } from '../../hooks/useDeviceDetect';
 
 interface SidebarProps {
@@ -366,6 +366,20 @@ export const Sidebar: React.FC<SidebarProps> = ({ onGenerateFlow, onImportPlan, 
                                 Keyboard shortcuts
                             </button>
                         )}
+                        <button
+                            onClick={() => {
+                                const next = (settings.theme ?? 'dark') === 'dark' ? 'light' : 'dark';
+                                updateSettings({ theme: next });
+                            }}
+                            className="flex items-center gap-2 text-xs text-gray-500 hover:text-gray-300 w-full px-2 py-2 touch:min-h-[44px]"
+                            title={`Switch to ${(settings.theme ?? 'dark') === 'dark' ? 'light' : 'dark'} theme`}
+                            aria-label={`Switch to ${(settings.theme ?? 'dark') === 'dark' ? 'light' : 'dark'} theme`}
+                        >
+                            {(settings.theme ?? 'dark') === 'dark'
+                                ? <Sun className="w-3 h-3" />
+                                : <Moon className="w-3 h-3" />}
+                            {(settings.theme ?? 'dark') === 'dark' ? 'Light theme' : 'Dark theme'}
+                        </button>
                         <button
                             onClick={() => setShowResetConfirm(true)}
                             className="flex items-center gap-2 text-xs text-gray-500 hover:text-red-400 w-full px-2 py-2"

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,33 @@
   --sar: env(safe-area-inset-right);
   --sab: env(safe-area-inset-bottom);
   --sal: env(safe-area-inset-left);
+
+  /* Surface tokens (dark default). Light theme overrides in [data-theme="light"]. */
+  --bg-app: #000;
+  --bg-canvas: #030712;      /* gray-950 */
+  --bg-panel: #0b1120;       /* near gray-900 */
+  --bg-panel-2: #111827;     /* gray-900 */
+  --bg-elevated: #1f2937;    /* gray-800 */
+  --bg-dot: #374151;         /* gray-700 — ReactFlow background dots */
+  --text-primary: #f9fafb;   /* gray-50 */
+  --text-secondary: #d1d5db; /* gray-300 */
+  --text-muted: #9ca3af;     /* gray-400 */
+  --border-default: #374151; /* gray-700 */
+  --border-strong: #4b5563;  /* gray-600 */
+}
+
+[data-theme="light"] {
+  --bg-app: #f9fafb;
+  --bg-canvas: #f3f4f6;
+  --bg-panel: #ffffff;
+  --bg-panel-2: #f9fafb;
+  --bg-elevated: #e5e7eb;
+  --bg-dot: #d1d5db;
+  --text-primary: #0f172a;
+  --text-secondary: #334155;
+  --text-muted: #64748b;
+  --border-default: #e5e7eb;
+  --border-strong: #cbd5e1;
 }
 
 html, body, #root {
@@ -17,7 +44,53 @@ html, body, #root {
   /* Prevent iOS Safari bounce scroll when modals/sheets are open */
   overscroll-behavior: none;
   -webkit-overflow-scrolling: touch;
-  background: #000;
+  background: var(--bg-app);
+}
+
+/* Light-theme utility overrides. Replaces Tailwind's hardcoded gray-9xx/8xx/7xx
+ * with our surface tokens only when [data-theme="light"] is set on <html>.
+ * Scoped narrowly so it doesn't affect semantic colors (red-500, purple-500, etc.). */
+[data-theme="light"] .bg-black { background-color: var(--bg-app) !important; }
+[data-theme="light"] .bg-gray-950 { background-color: var(--bg-canvas) !important; }
+[data-theme="light"] .bg-gray-900 { background-color: var(--bg-panel-2) !important; }
+[data-theme="light"] .bg-gray-800,
+[data-theme="light"] .bg-slate-800 { background-color: var(--bg-elevated) !important; }
+[data-theme="light"] .bg-slate-900 { background-color: var(--bg-panel) !important; }
+
+[data-theme="light"] .text-white,
+[data-theme="light"] .text-gray-50,
+[data-theme="light"] .text-gray-100,
+[data-theme="light"] .text-gray-200,
+[data-theme="light"] .text-slate-100,
+[data-theme="light"] .text-slate-200 { color: var(--text-primary) !important; }
+
+[data-theme="light"] .text-gray-300,
+[data-theme="light"] .text-gray-400,
+[data-theme="light"] .text-slate-300,
+[data-theme="light"] .text-slate-400 { color: var(--text-secondary) !important; }
+
+[data-theme="light"] .text-gray-500,
+[data-theme="light"] .text-gray-600,
+[data-theme="light"] .text-slate-500,
+[data-theme="light"] .text-slate-600 { color: var(--text-muted) !important; }
+
+[data-theme="light"] .border-gray-700,
+[data-theme="light"] .border-gray-800,
+[data-theme="light"] .border-slate-700,
+[data-theme="light"] .border-slate-800 { border-color: var(--border-default) !important; }
+
+[data-theme="light"] .border-gray-600,
+[data-theme="light"] .border-slate-600 { border-color: var(--border-strong) !important; }
+
+/* ReactFlow controls in light mode */
+[data-theme="light"] .react-flow__controls-button {
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border-default);
+}
+[data-theme="light"] .react-flow__controls-button svg { fill: var(--text-muted); }
+[data-theme="light"] .react-flow__controls {
+  border: 1px solid var(--border-default);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
 /* ReactFlow controls — dark theme override */


### PR DESCRIPTION
## Summary

- **Item 3 / Quick Win #2** from [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md)
- Adds a sidebar toggle that switches between dark (default) and light themes. Uses the already-typed `settings.theme` field.
- Approach: **CSS variables + utility-class overrides** scoped under `[data-theme="light"]` — existing ~80 hardcoded gray/slate classes are untouched. Keeps the PR small and reversible.

## Motivation

From FEATURE_OPPORTUNITIES.md Quick Win #2: "The type already has `theme: 'dark' | 'light'` — add a sidebar switch and CSS variable swap." A full token migration (the plan's 1d+ path) would churn 80+ component files; this approach remaps utilities with `!important` only when light is active, leaving dark mode a no-op refactor.

## Changes

- `src/index.css` — surface tokens (`--bg-canvas`, `--bg-panel`, `--text-primary`, `--border-default`, etc.) + `[data-theme="light"]` overrides for `bg-gray-*`, `bg-slate-*`, `text-*`, `border-*` utilities. Also re-themes ReactFlow controls.
- `src/App.tsx` — applies `settings.theme` to `<html data-theme>` via `useEffect`.
- `src/components/Canvas/CanvasArea.tsx` — `<Background color="var(--bg-dot)" />` so dots re-theme.
- `src/components/Layout/Sidebar.tsx` — Sun/Moon toggle in the sidebar footer.
- Docs: EXPECTED_UI_BEHAVIORS §10e, QA guide TH-1..TH-8.

## Test plan

- [ ] Dark is default on fresh load
- [ ] Toggle to light → canvas, sidebar, top bar, nodes all re-theme
- [ ] Toggle back to dark → reverts
- [ ] Theme persists through reload
- [ ] ReactFlow background dots and control buttons re-theme
- [ ] Red "Blocked" badge stays red in light mode (semantic colors preserved)
- [ ] Accent color bars still show correctly in both themes
- [ ] `npm run build` passes

## Notes / follow-ups

- Semantic colors (red, amber, accent palette) intentionally NOT remapped.
- If any component surface reads poorly in light mode (e.g. a gradient or a specific `bg-purple-*/20` shade), the fix is additive: extend `index.css` overrides rather than touching the component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
