### PR TITLE
Add Auto-Organize Canvas feature

### DIFF
--- a/QA_INVENTORY.md
+++ b/QA_INVENTORY.md
@@ -37,6 +37,7 @@ No URL router — single-page app with in-memory navigation stack.
 |-----------|------|---------|
 | CanvasArea | `src/components/Canvas/CanvasArea.tsx` | ReactFlow canvas, pan/zoom, shortcuts, touch gestures |
 | BlockedSpotlight | `src/components/Canvas/BlockedSpotlight.tsx` | Predecessor-trace overlay: pulse rings on blockers + chip bar / bottom sheet |
+| LayoutMenu | `src/components/Canvas/LayoutMenu.tsx` | Toolbar popover for Auto-Organize: picks strategy (cluster/grid/hierarchy/flow), optional selection-only scope, remembers last used |
 | ActionNode | `src/components/Nodes/ActionNode.tsx` | Task node: status cycle, inline edit, resize, notes, images, interactive blocked badge |
 | ContainerNode | `src/components/Nodes/ContainerNode.tsx` | Folder node: progress ring, magic expand, enter subgraph, images, interactive blocked badge |
 | NotesEditor | `src/components/Nodes/NotesEditor.tsx` | Notes popover/modal for nodes |
@@ -116,7 +117,8 @@ No URL router — single-page app with in-memory navigation stack.
 | Remove node | `removeNode(id)` | Removes edges + child graphs recursively |
 | Batch remove | `removeNodes(ids[])` | Batch with cleanup |
 | Cycle status | `cycleNodeStatus(id)` | todo → in_progress → done → todo |
-| Batch positions | `batchUpdatePositions(updates[])` | Drag optimization |
+| Batch positions | `batchUpdatePositions(updates[])` | Drag optimization; also used to commit Auto-Organize results as a single undo entry |
+| Auto-organize canvas | dispatch `{type:'auto-organize', strategy, nodeIds?}` → `computeLayout()` → `batchUpdatePositions()` | One of four strategies (cluster/grid/hierarchy/flow); animated via rfInstance.setNodes; nodeIds=[] = selection only; remembers last strategy in `settings.preferredLayoutStrategy` |
 | Add edge | `addEdge(edge)` | Connection between nodes |
 | Remove edge | `removeEdge(id)` | Single edge removal |
 | Enter graph | `enterGraph(graphId, nodeId, label)` | Push navStack |
@@ -216,7 +218,8 @@ No URL router — single-page app with in-memory navigation stack.
 |-----|---------------|---------------|
 | Container completion derived, not persisted | `logic.ts`, `StepDetailPanel.tsx`, `ActionNode.tsx`, `ContainerNode.tsx`, `ListView.tsx`, `CanvasArea.tsx` | Container progress, blocking logic, execution mode completion |
 | SaveIndicator driven by sync pipeline | `SaveIndicator.tsx`, `workspaceStore.ts`, `workspaceSync.ts`, `useWorkspaceSync.ts` | Save indicator accuracy, sync error visibility |
-| Typed canvas actions replace DOM events | `workspaceStore.ts`, `CanvasArea.tsx`, `TopBar.tsx`, `ActionNode.tsx`, `StepDetailPanel.tsx` | Delete-selected, fit-view, advance-next |
+| Typed canvas actions replace DOM events | `workspaceStore.ts`, `CanvasArea.tsx`, `TopBar.tsx`, `ActionNode.tsx`, `StepDetailPanel.tsx` | Delete-selected, fit-view, advance-next, auto-organize |
+| Auto-Organize Canvas feature | `src/layout/*`, `src/components/Canvas/LayoutMenu.tsx`, `CanvasArea.tsx`, `TopBar.tsx`, `workspaceStore.ts`, `types/index.ts` | New `src/layout/` engine (cluster/grid/hierarchy/flow strategies + overlap resolver + centroid-preserve); toolbar popover (desktop) + overflow-menu entries (touch); pane context-menu submenu; undo via `batchUpdatePositions` single commit; last-used strategy persisted via `settings.preferredLayoutStrategy` |
 | Code splitting / lazy loading | `App.tsx`, `vite.config.ts` | Bundle size, lazy modal loading, chunk splitting |
 | Focus View mode | `workspaceStore.ts`, `logic.ts`, `TopBar.tsx`, `App.tsx`, `FocusView.tsx`, `ParallelChooser.tsx` | Single-task focus mode with image/notes/status, auto-advance, parallel chooser, container drill-in, edit modal |
 

--- a/SPATIAL_TASKS_QA_GUIDE.md
+++ b/SPATIAL_TASKS_QA_GUIDE.md
@@ -412,6 +412,34 @@ User Action → Zustand Store Mutation → localStorage (immediate)
 
 ---
 
+### Flow 17: Auto-Organize Canvas
+
+**What the user is doing**: Cleaning up a messy board with the Auto-Organize feature.
+
+**Happy path**:
+1. User opens a graph whose nodes overlap or are scattered.
+2. Clicks the ✨ wand button in the top bar → popover lists four strategies (Cluster / Grid / Hierarchy / Flow) with short descriptions.
+3. Picks **Cluster** (default). Nodes animate (~450ms ease-out) into grouped clusters: connected components sit together, same-color/tag nodes adjacent inside each cluster.
+4. Presses **Ctrl+Z** once → exact prior positions restored (single undo step).
+5. Right-clicks the canvas pane → "Auto-Organize ▸" submenu offers the same four strategies.
+6. Selects a subset of nodes, opens the wand popover, ticks "Apply to selection only" → only the selected nodes move; the rest stay put.
+7. On touch: opens the TopBar overflow menu → "Auto-Organize" section lists the four strategies as buttons.
+8. Re-opening the popover highlights the last-used strategy as "Last used" (persisted in `settings.preferredLayoutStrategy`).
+
+**What could go wrong**:
+- Animation janks on graphs with many nodes (>200) or during concurrent drag.
+- Layout produces residual overlaps (the sweep-line resolver should catch these).
+- Strategy falls back silently on cyclic edges (Hierarchy/Flow → Grid) — make sure result is still laid out cleanly.
+- Selection-only run moves unselected nodes (bug in sentinel handling).
+- Undo fails to restore exact pre-organize positions (batchUpdatePositions commit order issue).
+- Cluster layout with no edges doesn't group by color/tag.
+- Popover stays open after applying a layout, or doesn't close on outside click.
+- Preferred strategy not persisted after reload.
+
+**Why it matters**: Core "spatial thinking" product promise — the canvas has to feel organized without destroying the user's mental map. Undo has to be bulletproof since users will experiment.
+
+---
+
 ## 3. Manual QA Test Plan
 
 > 90 test cases organized by feature area. Priority levels: P0 (Critical), P1 (High), P2 (Medium).
@@ -478,6 +506,18 @@ User Action → Zustand Store Mutation → localStorage (immediate)
 | QA-A037 | Escape Key | Layered Escape dismisses context menu first | Context menu is open while nodes are selected | 1. Select a node 2. Right-click to open context menu 3. Press Escape | Context menu closes; node selection remains | A second Escape press should then deselect the node | P1 |
 | QA-A038 | Escape Key | Layered Escape dismisses connect mode | Connect mode is active with nodes selected | 1. Select a node 2. Activate connect mode 3. Press Escape | Connect mode exits; node selection remains | A second Escape press should then deselect the node | P1 |
 | QA-A039 | Status | Blocked node shows not-allowed cursor | An ActionNode is blocked by unsatisfied dependencies | 1. Hover over the status icon of a blocked node | Cursor changes to not-allowed; clicking does not cycle status | Cursor should clearly indicate the interaction is disabled | P1 |
+| QA-A040 | Auto-Organize | Cluster layout from toolbar | A graph with 5+ nodes and at least 2 edges | 1. Drag nodes to overlap / scatter 2. Click the ✨ wand button in the top bar 3. Select "Cluster" | Nodes animate smoothly (~450ms) into grouped clusters; connected components sit together; no overlaps | Animation should not jank; final positions must have no AABB overlaps; popover closes after selection | P0 |
+| QA-A041 | Auto-Organize | Grid layout produces aligned rows/columns | A graph with 6+ nodes | 1. Open ✨ Auto-Organize 2. Select "Grid" | Nodes animate into clean rows/columns with consistent spacing | Columns must be aligned; rows left-justified; no overlaps | P1 |
+| QA-A042 | Auto-Organize | Hierarchy layout respects dependencies | A graph with a chain/tree of connected nodes | 1. Create a dependency chain A→B→C→D 2. Open ✨ Auto-Organize 3. Select "Hierarchy" | Nodes lay out top-to-bottom in dependency order: roots at top, leaves at bottom | Source nodes (no incoming edges) must be in the top layer; order within a layer should reduce edge crossings | P1 |
+| QA-A043 | Auto-Organize | Flow layout is left-to-right | A graph with a dependency chain | 1. Open ✨ Auto-Organize 2. Select "Flow" | Nodes lay out left-to-right along dependencies; same-depth siblings stack vertically | Left column = sources; right column = sinks | P1 |
+| QA-A044 | Auto-Organize | Undo restores exact prior positions | Any graph after running Auto-Organize | 1. Note positions of 2-3 nodes 2. Run any strategy 3. Press Ctrl+Z | All nodes return to their exact pre-organize positions | Must be a single undo step (not per-node); use zundo via batchUpdatePositions commit | P0 |
+| QA-A045 | Auto-Organize | Cyclic edges fall back to Grid for Hierarchy/Flow | A graph with a cycle (A→B→C→A) | 1. Open ✨ Auto-Organize 2. Select "Hierarchy" (or "Flow") | Layout engine detects cycle and falls back to Grid; no crash, no infinite recursion | Cycle detection must not throw; all nodes still laid out cleanly | P1 |
+| QA-A046 | Auto-Organize | Selection-only scope | A graph with 6+ nodes | 1. Select 3 nodes 2. Open ✨ Auto-Organize 3. Check "Apply to selection only" 4. Select "Grid" | Only the 3 selected nodes are repositioned; unselected nodes remain in place | Empty-array `nodeIds` sentinel in action resolves to current RF selection | P1 |
+| QA-A047 | Auto-Organize | Context menu submenu | A graph with 2+ nodes | 1. Right-click on an empty area of the canvas 2. Hover "Auto-Organize ▸" | Submenu shows 4 strategies (Cluster / Grid / Hierarchy / Flow); selecting one triggers the same animated layout | Submenu positioning stays within viewport | P1 |
+| QA-A048 | Auto-Organize | Preferred strategy persists across reload | Last used strategy was "Grid" | 1. Run Auto-Organize → Grid 2. Reload the page 3. Open ✨ Auto-Organize | "Grid" shows the "Last used" pill in the popover | Persisted via `settings.preferredLayoutStrategy` through localStorage + Supabase sync | P2 |
+| QA-A049 | Auto-Organize | Mobile overflow menu entries | Touch device | 1. Open the top-bar overflow menu (⋮) 2. Scroll to "Auto-Organize" section | Four strategy buttons listed (Cluster / Grid / Hierarchy / Flow); tapping any one runs the layout and closes the menu | All buttons meet 44px min touch target | P2 |
+| QA-A050 | Auto-Organize | Deterministic re-run | A graph with 10+ nodes | 1. Run Auto-Organize → Cluster 2. Undo 3. Run Auto-Organize → Cluster again | Second run produces identical positions to the first | `computeLayout` must be pure; seeded RNG and stable sort required | P2 |
+| QA-A051 | Auto-Organize | No-op on empty or single-node graph | 0 or 1 nodes on the canvas | 1. Run any Auto-Organize strategy | No animation, no error, no state change | Must not throw or create a stray undo entry | P2 |
 
 ### Group B: Connections, Navigation & Views (34 cases)
 

--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -20,13 +20,15 @@ import { ContextMenu, MenuItem } from '../UI/ContextMenu';
 import { ConfirmModal } from '../UI/ConfirmModal';
 import { ActionSheet } from '../UI/ActionSheet';
 import { FloatingActionButton } from '../UI/FloatingActionButton';
-import { Trash2, Circle, Clock, CheckCircle2, Plus, Layers, MousePointerClick, Sparkles, Maximize2, Palette, Ban } from 'lucide-react';
+import { Trash2, Circle, Clock, CheckCircle2, Plus, Layers, MousePointerClick, Sparkles, Maximize2, Palette, Ban, Wand2, Grid3x3, Network, GitBranch } from 'lucide-react';
 import { ACCENT_COLORS, ACCENT_BAR, ACCENT_LABEL } from '../../utils/accent';
 import type { AccentColor } from '../../types';
 import { useDeviceDetect } from '../../hooks/useDeviceDetect';
 import { isNodeActionable, getBlockingNodes, BlockingNodeInfo } from '../../utils/logic';
 import { StepDetailPanel } from '../ExecutionPanel/StepDetailPanel';
 import { BlockedSpotlight, useBlockingTitles } from './BlockedSpotlight';
+import { computeLayout } from '../../layout/layoutEngine';
+import type { LayoutStrategy } from '../../layout/layoutTypes';
 
 const nodeTypes = {
     container: ContainerNode,
@@ -458,6 +460,60 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
                 duration: 300,
                 maxZoom: 1.5,
             });
+        } else if (action.type === 'auto-organize') {
+            if (!activeGraphId) return;
+            const currentGraph = useWorkspaceStore.getState().graphs[activeGraphId];
+            if (!currentGraph || currentGraph.nodes.length < 2) return;
+
+            // Empty array = "use current RF selection". Undefined = "all nodes".
+            let selectedNodeIds: string[] | undefined = action.nodeIds;
+            if (selectedNodeIds && selectedNodeIds.length === 0) {
+                selectedNodeIds = reactFlowInstance.getNodes().filter(n => n.selected).map(n => n.id);
+                if (selectedNodeIds.length < 2) return;
+            }
+
+            const targets = computeLayout(
+                { nodes: currentGraph.nodes, edges: currentGraph.edges },
+                action.strategy,
+                { selectedNodeIds },
+            );
+            if (targets.length === 0) return;
+
+            const targetMap = new Map(targets.map(t => [t.id, t] as const));
+            const startPositions = new Map(
+                reactFlowInstance.getNodes().map(n => [n.id, { x: n.position.x, y: n.position.y }] as const)
+            );
+
+            const DURATION = 450;
+            const startTs = performance.now();
+            const ease = (t: number) => 1 - Math.pow(1 - t, 3); // ease-out cubic
+
+            const step = (now: number) => {
+                const t = Math.min(1, (now - startTs) / DURATION);
+                const k = ease(t);
+                const currentNodes = reactFlowInstance.getNodes();
+                reactFlowInstance.setNodes(currentNodes.map(n => {
+                    const tgt = targetMap.get(n.id);
+                    const start = startPositions.get(n.id);
+                    if (!tgt || !start) return n;
+                    return {
+                        ...n,
+                        position: {
+                            x: start.x + (tgt.x - start.x) * k,
+                            y: start.y + (tgt.y - start.y) * k,
+                        },
+                    };
+                }));
+                if (t < 1) {
+                    requestAnimationFrame(step);
+                } else {
+                    // Commit final positions to the store — single undo entry.
+                    batchUpdatePositions(targets);
+                    // Reframe.
+                    reactFlowInstance.fitView({ padding: 0.2, duration: 300 });
+                }
+            };
+            requestAnimationFrame(step);
         } else if (action.type === 'advance-next') {
             const fromNodeId = action.fromNodeId;
             if (!activeGraphId) return;
@@ -497,7 +553,7 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
                 }
             }, 100);
         }
-    }, [pendingCanvasAction, clearCanvasAction, deleteSelected, handleFitView, activeGraphId, reactFlowInstance]);
+    }, [pendingCanvasAction, clearCanvasAction, deleteSelected, handleFitView, activeGraphId, reactFlowInstance, batchUpdatePositions]);
 
     // (hasSelection tracked via store's setHasSelection)
 
@@ -796,6 +852,9 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
         }
 
         // Pane menu
+        const organize = (strategy: LayoutStrategy) => {
+            useWorkspaceStore.getState().dispatchCanvasAction({ type: 'auto-organize', strategy });
+        };
         return [
             {
                 label: 'New Action Node',
@@ -833,6 +892,17 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
                     });
                     setAutoEditNodeId(nodeId);
                 },
+            },
+            {
+                label: 'Auto-Organize',
+                icon: <Wand2 className="w-4 h-4" />,
+                submenu: [
+                    { label: 'Cluster (smart)', icon: <Sparkles className="w-4 h-4" />, onClick: () => organize('cluster') },
+                    { label: 'Grid', icon: <Grid3x3 className="w-4 h-4" />, onClick: () => organize('grid') },
+                    { label: 'Hierarchy', icon: <Network className="w-4 h-4" />, onClick: () => organize('hierarchy') },
+                    { label: 'Flow', icon: <GitBranch className="w-4 h-4" />, onClick: () => organize('flow') },
+                ],
+                onClick: () => {},
             },
         ];
     }, [activeGraphId, graph, reactFlowInstance, removeEdge, removeNode, removeNodes, updateNode, batchUpdateNodes, setNodeColor, addNode, setAutoEditNodeId]);

--- a/src/components/Canvas/LayoutMenu.tsx
+++ b/src/components/Canvas/LayoutMenu.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { clsx } from 'clsx';
+import { Wand2, Sparkles, Grid3x3, Network, GitBranch } from 'lucide-react';
+import { useWorkspaceStore } from '../../store/workspaceStore';
+import type { LayoutStrategy } from '../../layout/layoutTypes';
+
+interface StrategyDef {
+    id: LayoutStrategy;
+    label: string;
+    description: string;
+    icon: React.ReactNode;
+}
+
+const STRATEGIES: StrategyDef[] = [
+    { id: 'cluster',   label: 'Cluster',   description: 'Groups related nodes — smart default',     icon: <Sparkles className="w-4 h-4" /> },
+    { id: 'grid',      label: 'Grid',      description: 'Clean rows and columns',                   icon: <Grid3x3 className="w-4 h-4" /> },
+    { id: 'hierarchy', label: 'Hierarchy', description: 'Top-down tree by dependencies',            icon: <Network className="w-4 h-4" /> },
+    { id: 'flow',      label: 'Flow',      description: 'Left-to-right workflow',                   icon: <GitBranch className="w-4 h-4" /> },
+];
+
+interface Props {
+    /** Render as a compact button suitable for a toolbar. */
+    compact?: boolean;
+}
+
+/**
+ * Toolbar-anchored popover for Auto-Organize. Shows one button per strategy
+ * plus a "selection only" checkbox when nodes are selected. Remembers the
+ * last-used strategy in settings.preferredLayoutStrategy.
+ */
+export const LayoutMenu: React.FC<Props> = ({ compact = true }) => {
+    const [open, setOpen] = useState(false);
+    const [selectionOnly, setSelectionOnly] = useState(false);
+    const rootRef = useRef<HTMLDivElement>(null);
+
+    const dispatchCanvasAction = useWorkspaceStore(s => s.dispatchCanvasAction);
+    const updateSettings = useWorkspaceStore(s => s.updateSettings);
+    const preferred = useWorkspaceStore(s => s.settings.preferredLayoutStrategy);
+    const hasSelection = useWorkspaceStore(s => s._hasSelection);
+
+    useEffect(() => {
+        if (!open) return;
+        const handler = (e: Event) => {
+            if (rootRef.current && !rootRef.current.contains(e.target as HTMLElement)) {
+                setOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handler);
+        document.addEventListener('touchstart', handler);
+        return () => {
+            document.removeEventListener('mousedown', handler);
+            document.removeEventListener('touchstart', handler);
+        };
+    }, [open]);
+
+    const apply = (strategy: LayoutStrategy) => {
+        // Selection is held by ReactFlow; empty-array nodeIds is a sentinel
+        // telling CanvasArea to substitute the currently selected node IDs.
+        const nodeIds = selectionOnly && hasSelection ? [] : undefined;
+        updateSettings({ preferredLayoutStrategy: strategy });
+        dispatchCanvasAction({ type: 'auto-organize', strategy, nodeIds });
+        setOpen(false);
+    };
+
+    return (
+        <div className="relative" ref={rootRef}>
+            <button
+                onClick={() => setOpen(o => !o)}
+                className={clsx(
+                    compact
+                        ? 'p-1.5 rounded text-gray-400 hover:text-white hover:bg-gray-700 transition-colors'
+                        : 'flex items-center gap-3 w-full px-4 py-3 text-sm text-left text-gray-300 hover:bg-gray-700 transition-colors',
+                    'touch:min-h-[44px] touch:min-w-[44px] touch:flex touch:items-center touch:justify-center',
+                )}
+                title="Auto-Organize canvas"
+                aria-label="Auto-Organize canvas"
+            >
+                <Wand2 className="w-4 h-4 flex-shrink-0" />
+                {!compact && <span>Auto-Organize</span>}
+            </button>
+
+            {open && (
+                <div className="absolute right-0 top-full mt-1 bg-gray-800 border border-gray-700 rounded-lg shadow-xl z-50 py-1 min-w-[260px]">
+                    <div className="px-3 py-2 text-xs uppercase tracking-wide text-gray-500">
+                        Auto-Organize
+                    </div>
+                    {STRATEGIES.map(s => (
+                        <button
+                            key={s.id}
+                            onClick={() => apply(s.id)}
+                            className={clsx(
+                                'flex items-start gap-3 w-full px-3 py-2.5 text-left hover:bg-gray-700 transition-colors',
+                                preferred === s.id ? 'text-white' : 'text-gray-300',
+                            )}
+                        >
+                            <span className="mt-0.5 flex-shrink-0 text-gray-400">{s.icon}</span>
+                            <span className="flex-1 min-w-0">
+                                <span className="text-sm font-medium">{s.label}</span>
+                                {preferred === s.id && (
+                                    <span className="ml-2 text-[10px] uppercase tracking-wide text-purple-400">Last used</span>
+                                )}
+                                <span className="block text-xs text-gray-500 truncate">{s.description}</span>
+                            </span>
+                        </button>
+                    ))}
+                    {hasSelection && (
+                        <>
+                            <div className="border-t border-gray-700 my-1" />
+                            <label className="flex items-center gap-2 px-3 py-2 text-xs text-gray-300 cursor-pointer hover:bg-gray-700">
+                                <input
+                                    type="checkbox"
+                                    checked={selectionOnly}
+                                    onChange={e => setSelectionOnly(e.target.checked)}
+                                    className="accent-purple-500"
+                                />
+                                Apply to selection only
+                            </label>
+                        </>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/components/Layout/TopBar.tsx
+++ b/src/components/Layout/TopBar.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useWorkspaceStore } from '../../store/workspaceStore';
-import { ChevronRight, Home, Undo2, Redo2, Trash2, BoxSelect, Link, Menu, LayoutGrid, List, Crosshair, MoreVertical, Eye, Zap, Maximize2 } from 'lucide-react';
+import { ChevronRight, Home, Undo2, Redo2, Trash2, BoxSelect, Link, Menu, LayoutGrid, List, Crosshair, MoreVertical, Eye, Zap, Maximize2, Wand2, Sparkles, Grid3x3, Network, GitBranch } from 'lucide-react';
 import { clsx } from 'clsx';
 import { useStore } from 'zustand';
 import { useDeviceDetect } from '../../hooks/useDeviceDetect';
 import { SaveIndicator } from '../UI/SaveIndicator';
+import { LayoutMenu } from '../Canvas/LayoutMenu';
 
 export const TopBar: React.FC = () => {
     const { isTouchDevice, screenSize } = useDeviceDetect();
@@ -126,6 +127,7 @@ export const TopBar: React.FC = () => {
                 {/* Desktop: show all buttons inline */}
                 {!isTouchDevice && (
                     <>
+                        <LayoutMenu />
                         <button
                             onClick={() => undo()}
                             disabled={pastStates.length === 0}
@@ -220,6 +222,41 @@ export const TopBar: React.FC = () => {
                                 >
                                     <Maximize2 className="w-4 h-4 flex-shrink-0" />
                                     View Full Flow
+                                </button>
+
+                                <div className="border-t border-gray-700 my-1" />
+
+                                <div className="px-4 pt-2 pb-1 text-[10px] uppercase tracking-wide text-gray-500 flex items-center gap-2">
+                                    <Wand2 className="w-3 h-3" />
+                                    Auto-Organize
+                                </div>
+                                <button
+                                    onClick={() => { dispatchCanvasAction({ type: 'auto-organize', strategy: 'cluster' }); setOverflowOpen(false); }}
+                                    className="flex items-center gap-3 w-full px-4 py-3 text-sm text-left text-gray-300 hover:bg-gray-700 transition-colors"
+                                >
+                                    <Sparkles className="w-4 h-4 flex-shrink-0" />
+                                    Cluster (smart)
+                                </button>
+                                <button
+                                    onClick={() => { dispatchCanvasAction({ type: 'auto-organize', strategy: 'grid' }); setOverflowOpen(false); }}
+                                    className="flex items-center gap-3 w-full px-4 py-3 text-sm text-left text-gray-300 hover:bg-gray-700 transition-colors"
+                                >
+                                    <Grid3x3 className="w-4 h-4 flex-shrink-0" />
+                                    Grid
+                                </button>
+                                <button
+                                    onClick={() => { dispatchCanvasAction({ type: 'auto-organize', strategy: 'hierarchy' }); setOverflowOpen(false); }}
+                                    className="flex items-center gap-3 w-full px-4 py-3 text-sm text-left text-gray-300 hover:bg-gray-700 transition-colors"
+                                >
+                                    <Network className="w-4 h-4 flex-shrink-0" />
+                                    Hierarchy
+                                </button>
+                                <button
+                                    onClick={() => { dispatchCanvasAction({ type: 'auto-organize', strategy: 'flow' }); setOverflowOpen(false); }}
+                                    className="flex items-center gap-3 w-full px-4 py-3 text-sm text-left text-gray-300 hover:bg-gray-700 transition-colors"
+                                >
+                                    <GitBranch className="w-4 h-4 flex-shrink-0" />
+                                    Flow
                                 </button>
 
                                 <div className="border-t border-gray-700 my-1" />

--- a/src/layout/bboxUtils.ts
+++ b/src/layout/bboxUtils.ts
@@ -1,0 +1,69 @@
+import type { Node } from '../types';
+import type { Positioned } from './layoutTypes';
+
+const ACTION_DEFAULT_W = 200;
+const ACTION_DEFAULT_H = 50;
+const CONTAINER_DEFAULT_W = 200;
+const CONTAINER_DEFAULT_H = 80;
+
+export interface Size {
+    w: number;
+    h: number;
+}
+
+export function getNodeSize(node: Node): Size {
+    if (node.width && node.height) return { w: node.width, h: node.height };
+    if (node.type === 'container') {
+        return { w: node.width ?? CONTAINER_DEFAULT_W, h: node.height ?? CONTAINER_DEFAULT_H };
+    }
+    return { w: node.width ?? ACTION_DEFAULT_W, h: node.height ?? ACTION_DEFAULT_H };
+}
+
+export function buildSizeMap(nodes: Node[]): Map<string, Size> {
+    const map = new Map<string, Size>();
+    nodes.forEach(n => map.set(n.id, getNodeSize(n)));
+    return map;
+}
+
+/**
+ * Sweep-line overlap resolver. For any two AABBs that intersect, nudges the
+ * later-sorted one down (or right, on second pass) by enough to clear the
+ * collision plus `padding`. Two passes (by x then by y) catches the common
+ * residual overlaps after a strategy runs.
+ */
+export function resolveOverlaps(
+    positioned: Positioned[],
+    sizes: Map<string, Size>,
+    padding: number,
+): Positioned[] {
+    if (positioned.length < 2) return positioned;
+    const out = positioned.map(p => ({ ...p }));
+
+    const intersects = (a: Positioned, b: Positioned): boolean => {
+        const sa = sizes.get(a.id); const sb = sizes.get(b.id);
+        if (!sa || !sb) return false;
+        return (
+            a.x < b.x + sb.w + padding &&
+            a.x + sa.w + padding > b.x &&
+            a.y < b.y + sb.h + padding &&
+            a.y + sa.h + padding > b.y
+        );
+    };
+
+    for (let pass = 0; pass < 2; pass++) {
+        out.sort((a, b) => (pass === 0 ? a.x - b.x : a.y - b.y));
+        for (let i = 0; i < out.length; i++) {
+            for (let j = i + 1; j < out.length; j++) {
+                if (!intersects(out[i], out[j])) continue;
+                const sa = sizes.get(out[i].id)!;
+                if (pass === 0) {
+                    out[j].y = out[i].y + sa.h + padding;
+                } else {
+                    out[j].x = out[i].x + sa.w + padding;
+                }
+            }
+        }
+    }
+
+    return out;
+}

--- a/src/layout/layoutEngine.ts
+++ b/src/layout/layoutEngine.ts
@@ -1,0 +1,75 @@
+import type { LayoutInput, LayoutOptions, LayoutStrategy, Positioned } from './layoutTypes';
+import { resolveOptions } from './layoutTypes';
+import { gridLayout } from './strategies/gridLayout';
+import { hierarchyLayout } from './strategies/hierarchyLayout';
+import { clusterLayout } from './strategies/clusterLayout';
+import { flowLayout } from './strategies/flowLayout';
+import { buildSizeMap, resolveOverlaps } from './bboxUtils';
+import { preserveCentroid } from './preserveMap';
+
+/**
+ * Entry point. Pure function: same input + options → same output.
+ * Caller is responsible for applying the returned positions via the store.
+ */
+export function computeLayout(
+    input: LayoutInput,
+    strategy: LayoutStrategy,
+    options?: LayoutOptions,
+): Positioned[] {
+    const opts = resolveOptions(options);
+    const subset = opts.selectedNodeIds && opts.selectedNodeIds.length > 0
+        ? new Set(opts.selectedNodeIds)
+        : null;
+
+    const nodesToLayout = subset
+        ? input.nodes.filter(n => subset.has(n.id))
+        : input.nodes;
+
+    if (nodesToLayout.length === 0) return [];
+
+    // Single node — no work to do, return it in place.
+    if (nodesToLayout.length === 1) {
+        const n = nodesToLayout[0];
+        return [{ id: n.id, x: n.x, y: n.y }];
+    }
+
+    let computed: Positioned[];
+    switch (strategy) {
+        case 'grid':
+            computed = gridLayout(nodesToLayout, { gutterX: opts.gutterX, gutterY: opts.gutterY });
+            break;
+        case 'hierarchy':
+            computed = hierarchyLayout(nodesToLayout, input.edges, {
+                gutterX: opts.gutterX,
+                gutterY: opts.gutterY,
+                orientation: opts.orientation,
+            });
+            break;
+        case 'flow':
+            computed = flowLayout(nodesToLayout, input.edges, {
+                gutterX: opts.gutterX,
+                gutterY: opts.gutterY,
+            });
+            break;
+        case 'cluster':
+        default:
+            computed = clusterLayout(nodesToLayout, input.edges, {
+                gutterX: opts.gutterX,
+                gutterY: opts.gutterY,
+                clusterGap: opts.clusterGap,
+                seed: opts.seed,
+            });
+            break;
+    }
+
+    // Soft-preserve: keep the layout's centroid near where it was.
+    if (opts.preserveRelative) {
+        computed = preserveCentroid(nodesToLayout, computed);
+    }
+
+    // Hard safety net: resolve any residual overlaps.
+    const sizes = buildSizeMap(nodesToLayout);
+    computed = resolveOverlaps(computed, sizes, Math.min(opts.gutterX, opts.gutterY) / 2);
+
+    return computed;
+}

--- a/src/layout/layoutTypes.ts
+++ b/src/layout/layoutTypes.ts
@@ -1,0 +1,48 @@
+import type { Node, Edge } from '../types';
+
+export type LayoutStrategy = 'cluster' | 'grid' | 'hierarchy' | 'flow';
+
+export interface Positioned {
+    id: string;
+    x: number;
+    y: number;
+}
+
+export interface LayoutOptions {
+    /** Horizontal gap between nodes in a row/cluster. */
+    gutterX?: number;
+    /** Vertical gap between nodes. */
+    gutterY?: number;
+    /** Extra spacing between cluster groups. */
+    clusterGap?: number;
+    /** Subset of node IDs to lay out. If omitted, all nodes in the input are laid out. */
+    selectedNodeIds?: string[];
+    /** When true, translate/align the computed layout to stay near original positions. */
+    preserveRelative?: boolean;
+    /** Deterministic seed for strategies that use randomness (e.g. cluster). */
+    seed?: string;
+    /** Orientation hint for hierarchy layout. */
+    orientation?: 'top-down' | 'left-right';
+}
+
+export interface LayoutInput {
+    nodes: Node[];
+    edges: Edge[];
+}
+
+export const DEFAULT_GUTTER_X = 80;
+export const DEFAULT_GUTTER_Y = 60;
+export const DEFAULT_CLUSTER_GAP = 160;
+export const DEFAULT_SEED = 'spatialtasks-layout';
+
+export function resolveOptions(opts?: LayoutOptions): Required<Omit<LayoutOptions, 'selectedNodeIds'>> & { selectedNodeIds?: string[] } {
+    return {
+        gutterX: opts?.gutterX ?? DEFAULT_GUTTER_X,
+        gutterY: opts?.gutterY ?? DEFAULT_GUTTER_Y,
+        clusterGap: opts?.clusterGap ?? DEFAULT_CLUSTER_GAP,
+        preserveRelative: opts?.preserveRelative ?? true,
+        seed: opts?.seed ?? DEFAULT_SEED,
+        orientation: opts?.orientation ?? 'top-down',
+        selectedNodeIds: opts?.selectedNodeIds,
+    };
+}

--- a/src/layout/preserveMap.ts
+++ b/src/layout/preserveMap.ts
@@ -1,0 +1,31 @@
+import type { Node } from '../types';
+import type { Positioned } from './layoutTypes';
+
+/**
+ * Given the original node positions and a freshly-computed layout, translate
+ * the computed layout so its centroid matches the original centroid. Keeps
+ * the result anchored near where the user's eyes already are, preserving the
+ * mental map.
+ */
+export function preserveCentroid(original: Node[], computed: Positioned[]): Positioned[] {
+    if (computed.length === 0) return computed;
+
+    const origById = new Map(original.map(n => [n.id, n] as const));
+    const common = computed.filter(p => origById.has(p.id));
+    if (common.length === 0) return computed;
+
+    let ox = 0, oy = 0, cx = 0, cy = 0;
+    for (const p of common) {
+        const orig = origById.get(p.id)!;
+        ox += orig.x; oy += orig.y;
+        cx += p.x;   cy += p.y;
+    }
+    ox /= common.length; oy /= common.length;
+    cx /= common.length; cy /= common.length;
+
+    const dx = ox - cx;
+    const dy = oy - cy;
+    if (Math.abs(dx) < 0.5 && Math.abs(dy) < 0.5) return computed;
+
+    return computed.map(p => ({ id: p.id, x: p.x + dx, y: p.y + dy }));
+}

--- a/src/layout/strategies/clusterLayout.ts
+++ b/src/layout/strategies/clusterLayout.ts
@@ -1,0 +1,146 @@
+import seedrandom from 'seedrandom';
+import type { Node, Edge } from '../../types';
+import type { Positioned } from '../layoutTypes';
+import { getNodeSize } from '../bboxUtils';
+import { gridLayout } from './gridLayout';
+
+interface ClusterOpts {
+    gutterX: number;
+    gutterY: number;
+    clusterGap: number;
+    seed: string;
+    originX?: number;
+    originY?: number;
+}
+
+/**
+ * Union-find on edges to get connected components, then within each component
+ * group by meta.color / meta.tags[0] for visual coherence. Clusters laid out
+ * on an outer grid with extra spacing; members inside each cluster use the
+ * grid strategy so everything stays aligned.
+ */
+export function clusterLayout(nodes: Node[], edges: Edge[], opts: ClusterOpts): Positioned[] {
+    if (nodes.length === 0) return [];
+    const nodeIds = new Set(nodes.map(n => n.id));
+    const relevantEdges = edges.filter(e => nodeIds.has(e.source) && nodeIds.has(e.target));
+    const nodeById = new Map(nodes.map(n => [n.id, n] as const));
+
+    // Union-find on connectivity.
+    const parent = new Map<string, string>();
+    nodes.forEach(n => parent.set(n.id, n.id));
+    const find = (x: string): string => {
+        let r = x;
+        while (parent.get(r) !== r) r = parent.get(r)!;
+        while (parent.get(x) !== r) { const next = parent.get(x)!; parent.set(x, r); x = next; }
+        return r;
+    };
+    const union = (a: string, b: string) => { const ra = find(a); const rb = find(b); if (ra !== rb) parent.set(ra, rb); };
+    relevantEdges.forEach(e => union(e.source, e.target));
+
+    // Additionally, if there are no edges at all, group by color/tag so
+    // similar-looking nodes still cluster together.
+    if (relevantEdges.length === 0) {
+        const byKey = new Map<string, string[]>();
+        nodes.forEach(n => {
+            const key = n.meta?.color ?? n.meta?.tags?.[0] ?? '__none__';
+            (byKey.get(key) ?? byKey.set(key, []).get(key)!).push(n.id);
+        });
+        const components = Array.from(byKey.values());
+        return layoutClusters(components, nodeById, opts);
+    }
+
+    // Gather components from union-find, stably sorted for determinism.
+    const byRoot = new Map<string, string[]>();
+    nodes.forEach(n => {
+        const r = find(n.id);
+        (byRoot.get(r) ?? byRoot.set(r, []).get(r)!).push(n.id);
+    });
+
+    // Within each component, sort by (color, tag, id) so same-colored nodes
+    // sit together. Mental-map preservation happens later via preserveCentroid.
+    const components: string[][] = Array.from(byRoot.values()).map(comp =>
+        comp.sort((a, b) => {
+            const na = nodeById.get(a)!; const nb = nodeById.get(b)!;
+            const ca = na.meta?.color ?? ''; const cb = nb.meta?.color ?? '';
+            if (ca !== cb) return ca.localeCompare(cb);
+            const ta = na.meta?.tags?.[0] ?? ''; const tb = nb.meta?.tags?.[0] ?? '';
+            if (ta !== tb) return ta.localeCompare(tb);
+            return a.localeCompare(b);
+        })
+    );
+    // Larger components first so the biggest cluster anchors the layout.
+    components.sort((a, b) => b.length - a.length || a[0].localeCompare(b[0]));
+
+    return layoutClusters(components, nodeById, opts);
+}
+
+function layoutClusters(
+    components: string[][],
+    nodeById: Map<string, Node>,
+    opts: ClusterOpts,
+): Positioned[] {
+    // Use seeded RNG for any future jitter (currently unused but reserved).
+    // Calling rng() once keeps the seed advance consistent across runs.
+    const rng = seedrandom(opts.seed);
+    void rng();
+
+    const result: Positioned[] = [];
+    const originX = opts.originX ?? 0;
+    const originY = opts.originY ?? 0;
+
+    // Arrange clusters on an outer grid proportional to sqrt(cluster count).
+    const outerCols = Math.max(1, Math.ceil(Math.sqrt(components.length)));
+    const clusterBoxes: Array<{ ids: string[]; positions: Positioned[]; w: number; h: number }> = [];
+
+    for (const comp of components) {
+        const members: Node[] = comp.map(id => nodeById.get(id)!);
+        const innerCols = Math.max(1, Math.ceil(Math.sqrt(members.length)));
+        const positions = gridLayout(members, {
+            gutterX: opts.gutterX,
+            gutterY: opts.gutterY,
+            columns: innerCols,
+            originX: 0,
+            originY: 0,
+        });
+        // Bounding box of this cluster.
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        positions.forEach(p => {
+            const { w, h } = getNodeSize(nodeById.get(p.id)!);
+            minX = Math.min(minX, p.x);
+            minY = Math.min(minY, p.y);
+            maxX = Math.max(maxX, p.x + w);
+            maxY = Math.max(maxY, p.y + h);
+        });
+        clusterBoxes.push({
+            ids: comp,
+            positions,
+            w: maxX - minX,
+            h: maxY - minY,
+        });
+    }
+
+    // Outer grid packing — each row as tall as the tallest cluster in it.
+    const rowHeights: number[] = [];
+    const colWidths: number[] = new Array(outerCols).fill(0);
+    clusterBoxes.forEach((cb, i) => {
+        const row = Math.floor(i / outerCols);
+        const col = i % outerCols;
+        rowHeights[row] = Math.max(rowHeights[row] ?? 0, cb.h);
+        colWidths[col] = Math.max(colWidths[col], cb.w);
+    });
+
+    let cursorY = originY;
+    for (let row = 0; row * outerCols < clusterBoxes.length; row++) {
+        let cursorX = originX;
+        for (let col = 0; col < outerCols; col++) {
+            const idx = row * outerCols + col;
+            if (idx >= clusterBoxes.length) break;
+            const cb = clusterBoxes[idx];
+            cb.positions.forEach(p => result.push({ id: p.id, x: p.x + cursorX, y: p.y + cursorY }));
+            cursorX += colWidths[col] + opts.clusterGap;
+        }
+        cursorY += (rowHeights[row] ?? 0) + opts.clusterGap;
+    }
+
+    return result;
+}

--- a/src/layout/strategies/flowLayout.ts
+++ b/src/layout/strategies/flowLayout.ts
@@ -1,0 +1,25 @@
+import type { Node, Edge } from '../../types';
+import type { Positioned } from '../layoutTypes';
+import { hierarchyLayout } from './hierarchyLayout';
+
+interface FlowOpts {
+    gutterX: number;
+    gutterY: number;
+    originX?: number;
+    originY?: number;
+}
+
+/**
+ * Left-to-right workflow. Internally this is a hierarchy layout with
+ * left-right orientation — same topological layering and barycenter ordering,
+ * just rotated.
+ */
+export function flowLayout(nodes: Node[], edges: Edge[], opts: FlowOpts): Positioned[] {
+    return hierarchyLayout(nodes, edges, {
+        gutterX: opts.gutterX,
+        gutterY: opts.gutterY,
+        orientation: 'left-right',
+        originX: opts.originX,
+        originY: opts.originY,
+    });
+}

--- a/src/layout/strategies/gridLayout.ts
+++ b/src/layout/strategies/gridLayout.ts
@@ -1,0 +1,55 @@
+import type { Node } from '../../types';
+import type { Positioned } from '../layoutTypes';
+import { getNodeSize } from '../bboxUtils';
+
+interface GridOpts {
+    gutterX: number;
+    gutterY: number;
+    columns?: number;
+    originX?: number;
+    originY?: number;
+}
+
+/**
+ * Row/column packing. Columns default to ceil(sqrt(n)) so the result is
+ * roughly square. Each row is as tall as the tallest node in that row so
+ * there's never vertical overlap with neighbors above.
+ */
+export function gridLayout(nodes: Node[], opts: GridOpts): Positioned[] {
+    const { gutterX, gutterY } = opts;
+    if (nodes.length === 0) return [];
+
+    const cols = opts.columns ?? Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
+    // Sort deterministically so repeated runs produce identical layouts.
+    const ordered = [...nodes].sort((a, b) => a.id.localeCompare(b.id));
+
+    // Pre-compute row heights and column widths for alignment.
+    const rowHeights: number[] = [];
+    const colWidths: number[] = new Array(cols).fill(0);
+    ordered.forEach((n, i) => {
+        const { w, h } = getNodeSize(n);
+        const row = Math.floor(i / cols);
+        const col = i % cols;
+        rowHeights[row] = Math.max(rowHeights[row] ?? 0, h);
+        colWidths[col] = Math.max(colWidths[col], w);
+    });
+
+    const result: Positioned[] = [];
+    const originX = opts.originX ?? 0;
+    const originY = opts.originY ?? 0;
+    let cursorY = originY;
+
+    for (let row = 0; row * cols < ordered.length; row++) {
+        let cursorX = originX;
+        for (let col = 0; col < cols; col++) {
+            const idx = row * cols + col;
+            if (idx >= ordered.length) break;
+            const node = ordered[idx];
+            result.push({ id: node.id, x: cursorX, y: cursorY });
+            cursorX += colWidths[col] + gutterX;
+        }
+        cursorY += (rowHeights[row] ?? 0) + gutterY;
+    }
+
+    return result;
+}

--- a/src/layout/strategies/hierarchyLayout.ts
+++ b/src/layout/strategies/hierarchyLayout.ts
@@ -1,0 +1,118 @@
+import type { Node, Edge } from '../../types';
+import type { Positioned } from '../layoutTypes';
+import { getNodeSize } from '../bboxUtils';
+import { gridLayout } from './gridLayout';
+
+interface HierarchyOpts {
+    gutterX: number;
+    gutterY: number;
+    orientation: 'top-down' | 'left-right';
+    originX?: number;
+    originY?: number;
+}
+
+/**
+ * Longest-path layering (Sugiyama-lite) with one barycenter ordering pass to
+ * reduce edge crossings. Falls back to a grid when a cycle is detected.
+ */
+export function hierarchyLayout(nodes: Node[], edges: Edge[], opts: HierarchyOpts): Positioned[] {
+    if (nodes.length === 0) return [];
+    const nodeIds = new Set(nodes.map(n => n.id));
+    const relevantEdges = edges.filter(e => nodeIds.has(e.source) && nodeIds.has(e.target));
+
+    const incoming = new Map<string, string[]>();
+    const outgoing = new Map<string, string[]>();
+    nodes.forEach(n => { incoming.set(n.id, []); outgoing.set(n.id, []); });
+    relevantEdges.forEach(e => {
+        incoming.get(e.target)!.push(e.source);
+        outgoing.get(e.source)!.push(e.target);
+    });
+
+    // Longest-path from sources via memoized DFS; detects cycles.
+    const depth = new Map<string, number>();
+    const visiting = new Set<string>();
+    let cycleDetected = false;
+    const computeDepth = (id: string): number => {
+        if (cycleDetected) return 0;
+        if (depth.has(id)) return depth.get(id)!;
+        if (visiting.has(id)) { cycleDetected = true; return 0; }
+        visiting.add(id);
+        const preds = incoming.get(id) ?? [];
+        let d = 0;
+        for (const p of preds) d = Math.max(d, computeDepth(p) + 1);
+        visiting.delete(id);
+        depth.set(id, d);
+        return d;
+    };
+    nodes.forEach(n => computeDepth(n.id));
+
+    if (cycleDetected) {
+        return gridLayout(nodes, { gutterX: opts.gutterX, gutterY: opts.gutterY, originX: opts.originX, originY: opts.originY });
+    }
+
+    // Bucket by depth.
+    const layers: string[][] = [];
+    for (const n of nodes) {
+        const d = depth.get(n.id)!;
+        (layers[d] ??= []).push(n.id);
+    }
+
+    // Barycenter ordering: order each layer by the mean position of its predecessors
+    // in the previous layer. One forward pass is a good cheap heuristic.
+    const orderIndex = new Map<string, number>();
+    layers[0]?.sort((a, b) => a.localeCompare(b));
+    layers[0]?.forEach((id, i) => orderIndex.set(id, i));
+    for (let d = 1; d < layers.length; d++) {
+        const layer = layers[d];
+        layer.sort((a, b) => {
+            const predsA = incoming.get(a) ?? [];
+            const predsB = incoming.get(b) ?? [];
+            const baryA = predsA.length ? predsA.reduce((s, p) => s + (orderIndex.get(p) ?? 0), 0) / predsA.length : 0;
+            const baryB = predsB.length ? predsB.reduce((s, p) => s + (orderIndex.get(p) ?? 0), 0) / predsB.length : 0;
+            if (baryA !== baryB) return baryA - baryB;
+            return a.localeCompare(b);
+        });
+        layer.forEach((id, i) => orderIndex.set(id, i));
+    }
+
+    const nodeById = new Map(nodes.map(n => [n.id, n] as const));
+    const originX = opts.originX ?? 0;
+    const originY = opts.originY ?? 0;
+    const isTopDown = opts.orientation === 'top-down';
+
+    // Compute per-layer max size along the "stacking" axis; cross-axis uses
+    // cumulative sizes for alignment.
+    const result: Positioned[] = [];
+
+    if (isTopDown) {
+        // Layers stacked vertically; siblings in a layer spread horizontally.
+        let cursorY = originY;
+        for (const layer of layers) {
+            const rowHeight = Math.max(...layer.map(id => getNodeSize(nodeById.get(id)!).h));
+            const totalWidth = layer.reduce((s, id) => s + getNodeSize(nodeById.get(id)!).w, 0)
+                + opts.gutterX * Math.max(0, layer.length - 1);
+            let cursorX = originX - totalWidth / 2;
+            for (const id of layer) {
+                result.push({ id, x: cursorX, y: cursorY });
+                cursorX += getNodeSize(nodeById.get(id)!).w + opts.gutterX;
+            }
+            cursorY += rowHeight + opts.gutterY;
+        }
+    } else {
+        // Layers stacked horizontally; siblings spread vertically.
+        let cursorX = originX;
+        for (const layer of layers) {
+            const colWidth = Math.max(...layer.map(id => getNodeSize(nodeById.get(id)!).w));
+            const totalHeight = layer.reduce((s, id) => s + getNodeSize(nodeById.get(id)!).h, 0)
+                + opts.gutterY * Math.max(0, layer.length - 1);
+            let cursorY = originY - totalHeight / 2;
+            for (const id of layer) {
+                result.push({ id, x: cursorX, y: cursorY });
+                cursorY += getNodeSize(nodeById.get(id)!).h + opts.gutterY;
+            }
+            cursorX += colWidth + opts.gutterX;
+        }
+    }
+
+    return result;
+}

--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -3,6 +3,7 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 import { temporal } from 'zundo';
 import { v4 as uuidv4 } from 'uuid';
 import { Workspace, Node, Graph, Edge, Project, WorkspaceSettings, AccentColor } from '../types';
+import type { LayoutStrategy } from '../layout/layoutTypes';
 import { generateWorkspace } from '../utils/generator';
 import { saveGeminiConfig, loadGeminiConfig } from '../lib/workspaceSync';
 
@@ -12,7 +13,8 @@ export type CanvasAction =
     | { type: 'fit-view' }
     | { type: 'advance-next'; fromNodeId: string }
     | { type: 'spotlight-blockers'; sourceNodeId: string; blockerIds: string[] }
-    | { type: 'select-and-frame'; nodeId: string };
+    | { type: 'select-and-frame'; nodeId: string }
+    | { type: 'auto-organize'; strategy: LayoutStrategy; nodeIds?: string[] };
 
 interface WorkspaceState extends Workspace {
     // Transient flags (not persisted)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -108,6 +108,7 @@ export interface WorkspaceSettings {
     theme?: 'dark' | 'light';
     geminiApiKey?: string;
     geminiStatus?: GeminiConnectionStatus;
+    preferredLayoutStrategy?: 'cluster' | 'grid' | 'hierarchy' | 'flow';
     [key: string]: any;
 }
 


### PR DESCRIPTION
Introduces a user-triggered action that restructures a messy canvas into
one of four layouts — Cluster (default, groups connected components and
same-tag/color nodes), Grid, Hierarchy (top-down DAG), and Flow
(left-to-right workflow) — with an animated transition and single-undo
semantics via batchUpdatePositions.

- New src/layout/ engine: pure functions, deterministic, O(n + e) with
  a final overlap-resolve sweep; no new dependencies (dagre/elkjs
  deliberately avoided).
- Centroid-preserve soft heuristic keeps the result anchored near the
  user's mental map.
- UI: Wand2 toolbar button (desktop) opens a strategy popover with
  "Apply to selection only" when nodes are selected; overflow menu
  (touch) and pane context menu expose the four strategies. Last-used
  strategy remembered via settings.preferredLayoutStrategy.
- Animation: rfInstance.setNodes tween on requestAnimationFrame (~450ms
  ease-out), then a single batchUpdatePositions commit — one undo step.

Updated QA_INVENTORY.md and SPATIAL_TASKS_QA_GUIDE.md (Flow 17 +
QA-A040…A051) per CLAUDE.md requirements.