### PR TITLE
Fix mobile pan/pinch-zoom broken after Auto-Organize PR

### DIFF
--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -661,7 +661,14 @@ const CanvasInner: React.FC<CanvasInnerProps> = ({ onGenerateFlow }) => {
         if (!container) return;
 
         const handleTouchStart = (e: Event) => {
-            const touch = (e as TouchEvent).touches[0];
+            const te = e as TouchEvent;
+            // Bail on multi-touch so pinch-zoom reaches ReactFlow's d3-zoom
+            // without a phantom long-press timer racing it.
+            if (te.touches.length > 1) {
+                clearLongPress();
+                return;
+            }
+            const touch = te.touches[0];
             if (!touch) return;
 
             const target = touch.target as HTMLElement;


### PR DESCRIPTION
The long-press touch handler in CanvasArea started a 500ms timer on
every touchstart regardless of finger count. During a pinch gesture,
the second finger's touchstart re-entered the handler and scheduled a
new timer that could race ReactFlow's d3-zoom pinch detection — if the
user paused with two fingers planted, the action sheet would pop and
interrupt the gesture.

Bail out of the long-press flow when touches.length > 1 so multi-touch
gestures (pinch-zoom, two-finger pan) reach ReactFlow cleanly.

https://claude.ai/code/session_01RpYqrQ5dtsoY2VL7FoHPs9