### PR TITLE
Add project folders for sidebar grouping

### DIFF
--- a/QA_INVENTORY.md
+++ b/QA_INVENTORY.md
@@ -48,7 +48,7 @@ No URL router — single-page app with in-memory navigation stack.
 | Component | File | Purpose |
 |-----------|------|---------|
 | TopBar | `src/components/Layout/TopBar.tsx` | Breadcrumbs, undo/redo, view toggle, execution toggle |
-| Sidebar | `src/components/Layout/Sidebar.tsx` | Projects, settings, API key, sign out |
+| Sidebar | `src/components/Layout/Sidebar.tsx` | Projects, **project folders (create/rename/delete, collapse/expand, drag-and-drop on desktop, mobile move-to action sheet)**, settings, API key, sign out |
 
 ### UI Widgets
 | Component | File | Purpose |
@@ -57,6 +57,7 @@ No URL router — single-page app with in-memory navigation stack.
 | ContextMenu | `src/components/UI/ContextMenu.tsx` | Desktop right-click menus |
 | ActionSheet | `src/components/UI/ActionSheet.tsx` | Mobile bottom-sheet menus |
 | ConfirmModal | `src/components/UI/ConfirmModal.tsx` | Destructive action confirmation |
+| FolderDeleteModal | `src/components/UI/FolderDeleteModal.tsx` | Three-button modal for deleting a non-empty project folder (Cancel / Keep projects / Delete projects too) |
 | FloatingActionButton | `src/components/UI/FloatingActionButton.tsx` | Mobile FAB + bottom-sheet input |
 | SaveIndicator | `src/components/UI/SaveIndicator.tsx` | Save status (Saving.../Saved) |
 | ErrorBoundary | `src/components/UI/ErrorBoundary.tsx` | React error boundary |
@@ -97,8 +98,9 @@ No URL router — single-page app with in-memory navigation stack.
 
 | Entity | Key Fields | Notes |
 |--------|-----------|-------|
-| Workspace | version, projects[], graphs{}, navStack[], settings | Root data object |
-| Project | id, title, rootGraphId, createdAt, updatedAt | Top-level container |
+| Workspace | version, projects[], folders[], graphs{}, navStack[], settings | Root data object; `version: 2` since folders introduction |
+| Project | id, title, rootGraphId, createdAt, updatedAt, folderId? | Top-level container; `folderId` undefined means project sits at the root of the sidebar |
+| Folder | id, title, collapsed, order, createdAt, updatedAt | Sidebar-only grouping for projects; flat (one level); `collapsed` persisted; `order` controls sort |
 | Graph | id, projectId, title, nodes[], edges[], viewport? | Canvas content |
 | Node | id, graphId, type, title, x, y, status?, childGraphId?, meta? | action or container; `meta.images[]` holds image attachments, `meta.imagesOpen` persists the Visual References toggle |
 | ImageAttachment | id, dataUrl, name?, mimeType?, addedAt | Base64-encoded image stored under `node.meta.images[]` (V1) |
@@ -109,9 +111,14 @@ No URL router — single-page app with in-memory navigation stack.
 
 | Operation | Store Method | Side Effects |
 |-----------|-------------|-------------|
-| Create project | `createProject(title)` | Creates root graph, sets active |
+| Create project | `createProject(title, folderId?)` | Creates root graph, sets active; optional `folderId` nests the new project inside a folder |
 | Rename project | `renameProject(id, title)` | Updates timestamp |
 | Delete project | `deleteProject(id)` | Removes all graphs; blocks if last project |
+| Create folder | `createFolder(title)` | Appends a new folder to the workspace; returns new id; expanded by default |
+| Rename folder | `renameFolder(id, title)` | Trims title; empty string is a no-op |
+| Toggle folder collapsed | `toggleFolderCollapsed(id)` | Flips `collapsed`; persisted across reloads |
+| Move project to folder | `moveProjectToFolder(projectId, folderId \| null)` | Updates project's `folderId`; `null` moves to root (Ungrouped); no-op if already in target |
+| Delete folder | `deleteFolder(id, { deleteProjects })` | Either moves inner projects to root (Keep) or cascades deletion of projects + descendant graphs (Delete Too); Delete Too is blocked if it would empty the workspace |
 | Add node | `addNode(node)` | Adds to active graph; sets `autoEditNodeId` for keyboard/context-menu creation |
 | Update node | `updateNode(id, data)` | Partial update |
 | Remove node | `removeNode(id)` | Removes edges + child graphs recursively |
@@ -128,8 +135,8 @@ No URL router — single-page app with in-memory navigation stack.
 
 ## Persistence Pipeline
 
-1. **localStorage** — Zustand persist middleware, key `spatialtasks-workspace`
-2. **Supabase** — Debounced (2s) upsert to `workspaces` table on every mutation
+1. **localStorage** — Zustand persist middleware, key `spatialtasks-workspace`, current version `2`. A `migrate(persistedState, fromVersion)` hook in the store injects `folders: []` and normalizes `project.folderId` for any v<2 blob.
+2. **Supabase** — Debounced (2s) upsert to `workspaces` table on every mutation. Schema is a single JSONB column, so no server migration is needed; `hydrateFromSupabase` self-heals missing `folders` on load.
 3. **Gemini keys** — Isolated in localStorage key `spatialtasks-gemini-config`, never sent to Supabase
 
 ### Hydration Order
@@ -222,6 +229,7 @@ No URL router — single-page app with in-memory navigation stack.
 | Auto-Organize Canvas feature | `src/layout/*`, `src/components/Canvas/LayoutMenu.tsx`, `CanvasArea.tsx`, `TopBar.tsx`, `workspaceStore.ts`, `types/index.ts` | New `src/layout/` engine (cluster/grid/hierarchy/flow strategies + overlap resolver + centroid-preserve); toolbar popover (desktop) + overflow-menu entries (touch); pane context-menu submenu; undo via `batchUpdatePositions` single commit; last-used strategy persisted via `settings.preferredLayoutStrategy` |
 | Code splitting / lazy loading | `App.tsx`, `vite.config.ts` | Bundle size, lazy modal loading, chunk splitting |
 | Focus View mode | `workspaceStore.ts`, `logic.ts`, `TopBar.tsx`, `App.tsx`, `FocusView.tsx`, `ParallelChooser.tsx` | Single-task focus mode with image/notes/status, auto-advance, parallel chooser, container drill-in, edit modal |
+| Project Folders (grouping) | `types/index.ts`, `workspaceStore.ts`, `utils/generator.ts`, `components/Layout/Sidebar.tsx`, `components/UI/FolderDeleteModal.tsx` | Flat (one-level) folders for grouping projects in the sidebar. Covers folder CRUD, collapse/expand persisted state, HTML5 drag-and-drop of projects onto folder headers on desktop, touch fallback (tap ⋯ → "Move to folder…" action sheet), three-button delete modal (Cancel / Keep projects / Delete projects too), v1→v2 migration, zundo tracking of `folders`, and self-healing of Supabase v1 blobs. |
 
 ## Related Documents
 

--- a/SPATIAL_TASKS_QA_GUIDE.md
+++ b/SPATIAL_TASKS_QA_GUIDE.md
@@ -334,6 +334,35 @@ User Action → Zustand Store Mutation → localStorage (immediate)
 
 ---
 
+### Flow 13b: Project Folders (Grouping)
+
+**What the user is doing**: Organizing projects into folders (e.g. a "Music" folder) so the sidebar is browsable with many projects. Folders are flat (one level), live in the sidebar only, and never appear in the in-project breadcrumb.
+
+**Happy path**:
+1. Click the folder+ icon (next to the project+ icon) → inline folder-name input appears → type name, press Enter → folder appears below "Ungrouped" list.
+2. Double-click a folder title → inline rename → Enter to save.
+3. Click the chevron (or the folder title) → folder expands/collapses. State persists across reloads.
+4. Desktop: drag a project row onto a folder header → purple drop-highlight while hovering → release → project nests inside. Drag a nested project back onto the "Ungrouped" section → returns to root.
+5. Click the "+" button on a folder header → inline "New project" form opens inside that folder → newly created project inherits the folder.
+6. Hover a folder, click trash:
+   - Empty folder → single-button confirm modal.
+   - Folder with projects → three-button modal: **Cancel** / **Keep projects** (moves them to Ungrouped) / **Delete projects too** (cascades deletion).
+7. Mobile: drag disabled. Tap the "⋯" button on a project row → action sheet with **Rename**, **Move to folder…**, **Delete**. Picking "Move to folder…" lists Ungrouped, each folder, and a "New folder…" shortcut.
+8. Cmd/Ctrl+Z undoes folder create, rename, move, and delete.
+
+**What could go wrong**:
+- Legacy (v1) workspace without a `folders` array breaks on load — migration must inject `folders: []` so the UI renders normally.
+- "Delete projects too" on a folder that contains every project in the workspace — must be blocked with a toast, never auto-create a replacement blank.
+- Active project is inside the deleted folder — active selection must fall back to first remaining project (same behavior as single-project delete).
+- Drop event fires twice (nested drop targets) — project ends up in the wrong folder.
+- Touch long-press triggers native browser drag or context menu instead of the action sheet.
+- Collapse state lost on reload (means persistence wasn't wired through).
+- Supabase sync: folder created on device A doesn't appear on device B after reload.
+
+**Why it matters**: As users accumulate projects across life domains (music, work, hobbies), a flat list becomes unusable. This is the primary organizational affordance at the project level.
+
+---
+
 ### Flow 14: View Mode Switching (Graph ↔ List ↔ Focus)
 
 **What the user is doing**: Toggling between canvas, list, and focus views.
@@ -576,7 +605,7 @@ User Action → Zustand Store Mutation → localStorage (immediate)
 | QA-B042 | Focus view | View toggle hidden but reachable on small screens | Mobile/small viewport (< sm breakpoint) | 1. Open the TopBar overflow menu (kebab/MoreVertical icon). | The overflow menu lists Node View, List View, AND Focus View options, each with the active state highlighted when current. | Tapping switches view mode and closes the menu; new Focus button must not be left out of mobile UX | P0 |
 | QA-B043 | Focus view | Desktop keyboard shortcuts | Focus View on desktop with one task showing | 1. Press Space. 2. Press Space again. 3. Press → key. 4. Press ← key. 5. Press Esc. | Space/Enter cycles status (and may auto-advance); → triggers Skip; ← triggers Prev; Esc switches viewMode back to 'list'. | Shortcuts must NOT fire while typing in the Edit modal's textarea; should be inert on touch devices | P2 |
 
-### Group C: Projects, Persistence & AI (21 cases)
+### Group C: Projects, Persistence & AI (33 cases)
 
 | Test ID | Area | Scenario | Preconditions | Steps | Expected Result | Watch For | Priority |
 |---------|------|----------|---------------|-------|----------------|-----------|----------|
@@ -601,6 +630,18 @@ User Action → Zustand Store Mutation → localStorage (immediate)
 | QA-C019 | Markdown Import | Import empty or malformed markdown | App loaded | 1. Open MarkdownImporter 2. Paste empty string or random non-markdown text 3. Confirm import | Graceful handling — either an error toast saying invalid input or a minimal project with a single node from the text | Should not crash or produce an empty project with zero nodes | P2 |
 | QA-C020 | JSON Import | Import valid workspace JSON | App loaded, have a previously exported JSON file | 1. Open JSON import option 2. Select a valid workspace JSON file 3. Confirm import | Workspace fully replaced with imported data — all nodes, edges, positions, and project structure match the JSON | SaveIndicator should trigger a save after import; previous workspace is gone (warn user beforehand) | P1 |
 | QA-C021 | JSON Import | Import invalid JSON file | App loaded | 1. Open JSON import 2. Select a file with invalid JSON or wrong schema 3. Confirm import | Validation fails; error toast displayed; workspace remains unchanged | Should validate schema structure, not just JSON parse; no partial import leaving workspace in broken state | P1 |
+| QA-C022 | Project Folders | Create folder via FolderPlus button | App loaded | 1. Click FolderPlus icon in sidebar 2. Type "Music", press Enter | Folder "Music" appears in sidebar below any existing folders; persists after reload | Empty name should be rejected or default to "Untitled Folder"; new folder should be expanded by default | P1 |
+| QA-C023 | Project Folders | Rename folder via double-click | At least one folder exists | 1. Double-click folder title 2. Type new name 3. Press Enter | Folder renamed; change persists after reload | Empty name reverts to previous title; Escape cancels without saving | P2 |
+| QA-C024 | Project Folders | Drag project onto folder (desktop) | Desktop viewport; at least one folder and one ungrouped project | 1. Drag a project row onto the folder header 2. Observe purple ring/tint on drop target 3. Release | Project nests under folder; persists after reload | No drop should occur if released outside a valid target; dragged row shows opacity-50 during drag | P1 |
+| QA-C025 | Project Folders | Drag project out to Ungrouped | Project nested inside a folder | 1. Drag project from folder onto the "Ungrouped" section 2. Release | Project returns to the top (ungrouped) level | If dropped onto its own current folder, nothing changes (no-op) | P2 |
+| QA-C026 | Project Folders | Collapse/expand state persists | Folder with one or more projects | 1. Click chevron to collapse folder 2. Reload the page | Folder remains collapsed after reload | Expand also persists; collapse is undoable via Ctrl+Z but acceptable | P2 |
+| QA-C027 | Project Folders | Delete folder with projects — Keep | Folder contains >=1 project | 1. Click trash on folder 2. Modal shows 3 buttons 3. Click "Keep projects (move to root)" | Folder removed; its projects reappear in Ungrouped section; no project content lost | Active project selection should remain unchanged | P1 |
+| QA-C028 | Project Folders | Delete folder with projects — Delete Too | Folder contains >=1 project; workspace has at least 1 project outside folder | 1. Click trash on folder 2. Click "Delete projects too" | Folder and all its projects deleted including graphs; if active project was among deleted, falls back to first remaining project | Cmd+Z restores folder + projects + graphs | P1 |
+| QA-C029 | Project Folders | Delete would empty workspace — blocked | Folder contains every project in workspace | 1. Click trash 2. Click "Delete projects too" | Operation blocked with error toast ("Can't delete — workspace must keep at least one project"); nothing is deleted | No silent auto-blank project creation | P1 |
+| QA-C030 | Project Folders | Delete empty folder | Empty folder exists | 1. Click trash on empty folder | Single-button ConfirmModal appears (not the 3-button modal); confirming removes the folder | Should NOT show the keep/delete choice when there are no projects inside | P2 |
+| QA-C031 | Project Folders | Create project inside folder | Folder exists and is expanded | 1. Hover folder header 2. Click "+" button on the folder header 3. Type name, Enter | New project is created with folderId set to that folder; appears inside the folder immediately | Creating via the top-level "+" still creates an ungrouped project | P2 |
+| QA-C032 | Project Folders | Mobile action sheet: Move to folder | Mobile viewport, >=1 folder, >=1 project | 1. Tap "⋯" button on a project row 2. Pick "Move to folder…" 3. Pick a target folder | Project is moved into that folder; action sheet closes with success toast | "New folder…" shortcut creates a folder and moves project into it in one step | P1 |
+| QA-C033 | Project Folders | v1 → v2 migration | User has pre-folders localStorage data | 1. Manually edit localStorage `spatialtasks-workspace` to set `version: 1` and remove `folders` key 2. Reload the app | App loads without error; `folders: []` is injected; all existing projects appear in Ungrouped; version bumps to 2 on next save | Supabase-hydrated v1 workspace self-heals the same way | P0 |
 
 ### Group D: Auth, Mobile & Edge Cases (21 cases)
 

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,12 +1,14 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useWorkspaceStore } from '../../store/workspaceStore';
 import { useAuthStore } from '../../store/authStore';
 import { useToastStore } from '../UI/Toast';
 import { ConfirmModal } from '../UI/ConfirmModal';
+import { FolderDeleteModal } from '../UI/FolderDeleteModal';
 import { supabase } from '../../lib/supabase';
 import { clsx } from 'clsx';
-import { FolderGit2, RefreshCw, Settings, Eye, EyeOff, KeyRound, Trash2, ArrowLeft, ExternalLink, LogOut, User, Lock, Plus, Sparkles, FileUp, Keyboard, Sun, Moon } from 'lucide-react';
+import { FolderGit2, RefreshCw, Settings, Eye, EyeOff, KeyRound, Trash2, ArrowLeft, ExternalLink, LogOut, User, Lock, Plus, Sparkles, FileUp, Keyboard, Sun, Moon, FolderPlus, ChevronDown, ChevronRight, MoreHorizontal } from 'lucide-react';
 import { useDeviceDetect } from '../../hooks/useDeviceDetect';
+import type { Project } from '../../types';
 
 interface SidebarProps {
     onGenerateFlow?: () => void;
@@ -19,11 +21,17 @@ export const Sidebar: React.FC<SidebarProps> = ({ onGenerateFlow, onImportPlan, 
     const sidebarOpen = useWorkspaceStore(state => state.sidebarOpen);
     const closeSidebar = useWorkspaceStore(state => state.closeSidebar);
     const projects = useWorkspaceStore(state => state.projects);
+    const folders = useWorkspaceStore(state => state.folders);
     const activeProjectId = useWorkspaceStore(state => state.activeProjectId);
     const loadProject = useWorkspaceStore(state => state.loadProject);
     const createProject = useWorkspaceStore(state => state.createProject);
     const deleteProject = useWorkspaceStore(state => state.deleteProject);
     const renameProject = useWorkspaceStore(state => state.renameProject);
+    const createFolder = useWorkspaceStore(state => state.createFolder);
+    const renameFolder = useWorkspaceStore(state => state.renameFolder);
+    const deleteFolder = useWorkspaceStore(state => state.deleteFolder);
+    const toggleFolderCollapsed = useWorkspaceStore(state => state.toggleFolderCollapsed);
+    const moveProjectToFolder = useWorkspaceStore(state => state.moveProjectToFolder);
     const resetWorkspace = useWorkspaceStore(state => state.resetWorkspace);
     const settings = useWorkspaceStore(state => state.settings);
     const updateSettings = useWorkspaceStore(state => state.updateSettings);
@@ -37,10 +45,47 @@ export const Sidebar: React.FC<SidebarProps> = ({ onGenerateFlow, onImportPlan, 
     const [changingPassword, setChangingPassword] = useState(false);
     const [isCreating, setIsCreating] = useState(false);
     const [newProjectTitle, setNewProjectTitle] = useState('');
+    // Target folder for inline-create. null = ungrouped root, string = folder id.
+    const [creatingInFolderId, setCreatingInFolderId] = useState<string | null>(null);
     const [showResetConfirm, setShowResetConfirm] = useState(false);
     const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
     const [editingProjectId, setEditingProjectId] = useState<string | null>(null);
     const [editingProjectTitle, setEditingProjectTitle] = useState('');
+
+    // Folder-related state
+    const [isCreatingFolder, setIsCreatingFolder] = useState(false);
+    const [newFolderTitle, setNewFolderTitle] = useState('');
+    const [editingFolderId, setEditingFolderId] = useState<string | null>(null);
+    const [editingFolderTitle, setEditingFolderTitle] = useState('');
+    const [folderDeleteId, setFolderDeleteId] = useState<string | null>(null);
+    const [emptyFolderDeleteId, setEmptyFolderDeleteId] = useState<string | null>(null);
+
+    // Drag and drop state
+    const [draggingProjectId, setDraggingProjectId] = useState<string | null>(null);
+    const [dragOverTarget, setDragOverTarget] = useState<string | null>(null); // 'ungrouped' | folderId
+
+    // Mobile action sheet state
+    const [mobileActionProjectId, setMobileActionProjectId] = useState<string | null>(null);
+    const [moveSheetProjectId, setMoveSheetProjectId] = useState<string | null>(null);
+
+    const sortedFolders = useMemo(
+        () => folders.slice().sort((a, b) => a.order - b.order),
+        [folders]
+    );
+    const ungroupedProjects = useMemo(
+        () => projects.filter(p => !p.folderId),
+        [projects]
+    );
+    const projectsByFolder = useMemo(() => {
+        const map = new Map<string, Project[]>();
+        folders.forEach(f => map.set(f.id, []));
+        projects.forEach(p => {
+            if (p.folderId && map.has(p.folderId)) {
+                map.get(p.folderId)!.push(p);
+            }
+        });
+        return map;
+    }, [folders, projects]);
 
     const geminiStatus = settings.geminiStatus || (settings.geminiApiKey ? 'configured' : 'no_key');
 
@@ -81,6 +126,79 @@ export const Sidebar: React.FC<SidebarProps> = ({ onGenerateFlow, onImportPlan, 
 
     // On mobile, hide unless drawer is open
     if (isMobile && !sidebarOpen) return null;
+
+    const renderProjectRow = (project: Project) => {
+        const isEditing = editingProjectId === project.id;
+        const isDragging = draggingProjectId === project.id;
+        const canDrag = !isMobile && !isEditing;
+        return (
+            <div
+                key={project.id}
+                className={clsx("group relative flex items-center", isDragging && "opacity-50")}
+                draggable={canDrag}
+                onDragStart={canDrag ? (e) => {
+                    e.dataTransfer.setData('application/x-spatialtasks-project', project.id);
+                    e.dataTransfer.effectAllowed = 'move';
+                    setDraggingProjectId(project.id);
+                } : undefined}
+                onDragEnd={canDrag ? () => {
+                    setDraggingProjectId(null);
+                    setDragOverTarget(null);
+                } : undefined}
+            >
+                {isEditing ? (
+                    <input
+                        autoFocus
+                        value={editingProjectTitle}
+                        onChange={(e) => setEditingProjectTitle(e.target.value)}
+                        onBlur={() => {
+                            const trimmed = editingProjectTitle.trim();
+                            if (trimmed && trimmed !== project.title) {
+                                renameProject(project.id, trimmed);
+                            }
+                            setEditingProjectId(null);
+                        }}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+                            if (e.key === 'Escape') setEditingProjectId(null);
+                        }}
+                        className="w-full px-3 py-2 rounded-md text-sm bg-gray-800 border border-purple-600 text-white placeholder-gray-500 focus:outline-none"
+                    />
+                ) : (
+                    <button
+                        onClick={() => { loadProject(project.id); if (isMobile) closeSidebar(); }}
+                        onDoubleClick={() => { setEditingProjectId(project.id); setEditingProjectTitle(project.title); }}
+                        className={clsx(
+                            "w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
+                            activeProjectId === project.id
+                                ? "bg-purple-900/30 text-purple-300 border border-purple-800"
+                                : "text-gray-400 hover:bg-gray-800 hover:text-gray-200"
+                        )}
+                    >
+                        {project.title}
+                    </button>
+                )}
+                {!isEditing && isMobile && (
+                    <button
+                        onClick={(e) => { e.stopPropagation(); setMobileActionProjectId(project.id); }}
+                        className="absolute right-1 p-1 rounded text-gray-600 opacity-70 hover:text-gray-300 hover:bg-gray-800 transition-all min-h-[44px] min-w-[44px] flex items-center justify-center"
+                        title="Project actions"
+                    >
+                        <MoreHorizontal className="w-3.5 h-3.5" />
+                    </button>
+                )}
+                {!isEditing && !isMobile && projects.length > 1 && (
+                    <button
+                        onClick={(e) => { e.stopPropagation(); setDeleteConfirmId(project.id); }}
+                        className="absolute right-1 p-1 rounded text-gray-600 opacity-0 group-hover:opacity-100 hover:text-red-400 hover:bg-gray-800 transition-all"
+                        title="Delete project"
+                    >
+                        <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                )}
+            </div>
+        );
+    };
 
     const sidebarContent = (
         <div className={clsx(
@@ -261,16 +379,56 @@ export const Sidebar: React.FC<SidebarProps> = ({ onGenerateFlow, onImportPlan, 
                         )}
                         <div className="flex items-center justify-between mb-2 px-2">
                             <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Projects</h3>
-                            <button
-                                onClick={() => setIsCreating(true)}
-                                className="p-0.5 rounded text-gray-500 hover:text-purple-400 hover:bg-gray-800 transition-colors"
-                                title="New project"
-                            >
-                                <Plus className="w-4 h-4" />
-                            </button>
+                            <div className="flex items-center gap-0.5">
+                                <button
+                                    onClick={() => { setIsCreatingFolder(true); setIsCreating(false); }}
+                                    className="p-0.5 rounded text-gray-500 hover:text-purple-400 hover:bg-gray-800 transition-colors"
+                                    title="New folder"
+                                >
+                                    <FolderPlus className="w-4 h-4" />
+                                </button>
+                                <button
+                                    onClick={() => { setIsCreating(true); setCreatingInFolderId(null); setIsCreatingFolder(false); }}
+                                    className="p-0.5 rounded text-gray-500 hover:text-purple-400 hover:bg-gray-800 transition-colors"
+                                    title="New project"
+                                >
+                                    <Plus className="w-4 h-4" />
+                                </button>
+                            </div>
                         </div>
                         <div className="space-y-1">
-                            {isCreating && (
+                            {isCreatingFolder && (
+                                <form
+                                    onSubmit={(e) => {
+                                        e.preventDefault();
+                                        const title = newFolderTitle.trim() || 'Untitled Folder';
+                                        createFolder(title);
+                                        setNewFolderTitle('');
+                                        setIsCreatingFolder(false);
+                                        addToast(`Created folder "${title}"`, 'success');
+                                    }}
+                                >
+                                    <input
+                                        autoFocus
+                                        value={newFolderTitle}
+                                        onChange={(e) => setNewFolderTitle(e.target.value)}
+                                        onBlur={() => {
+                                            if (!newFolderTitle.trim()) {
+                                                setIsCreatingFolder(false);
+                                            }
+                                        }}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Escape') {
+                                                setNewFolderTitle('');
+                                                setIsCreatingFolder(false);
+                                            }
+                                        }}
+                                        placeholder="Folder name..."
+                                        className="w-full px-3 py-2 rounded-md text-sm bg-gray-800 border border-purple-600 text-white placeholder-gray-500 focus:outline-none focus:border-purple-400"
+                                    />
+                                </form>
+                            )}
+                            {isCreating && creatingInFolderId === null && (
                                 <form
                                     onSubmit={(e) => {
                                         e.preventDefault();
@@ -301,51 +459,187 @@ export const Sidebar: React.FC<SidebarProps> = ({ onGenerateFlow, onImportPlan, 
                                     />
                                 </form>
                             )}
-                            {projects.map(project => (
-                                <div key={project.id} className="group relative flex items-center">
-                                    {editingProjectId === project.id ? (
-                                        <input
-                                            autoFocus
-                                            value={editingProjectTitle}
-                                            onChange={(e) => setEditingProjectTitle(e.target.value)}
-                                            onBlur={() => {
-                                                const trimmed = editingProjectTitle.trim();
-                                                if (trimmed && trimmed !== project.title) {
-                                                    renameProject(project.id, trimmed);
-                                                }
-                                                setEditingProjectId(null);
-                                            }}
-                                            onKeyDown={(e) => {
-                                                if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
-                                                if (e.key === 'Escape') setEditingProjectId(null);
-                                            }}
-                                            className="w-full px-3 py-2 rounded-md text-sm bg-gray-800 border border-purple-600 text-white placeholder-gray-500 focus:outline-none"
-                                        />
-                                    ) : (
-                                        <button
-                                            onClick={() => { loadProject(project.id); if (isMobile) closeSidebar(); }}
-                                            onDoubleClick={() => { setEditingProjectId(project.id); setEditingProjectTitle(project.title); }}
+
+                            {/* Ungrouped section — drop zone for projects moved out of folders */}
+                            <div
+                                className={clsx(
+                                    "rounded-md transition-colors",
+                                    dragOverTarget === 'ungrouped' && "ring-1 ring-purple-500 bg-purple-900/10"
+                                )}
+                                onDragOver={(e) => {
+                                    if (!draggingProjectId) return;
+                                    e.preventDefault();
+                                    e.dataTransfer.dropEffect = 'move';
+                                    if (dragOverTarget !== 'ungrouped') setDragOverTarget('ungrouped');
+                                }}
+                                onDragLeave={(e) => {
+                                    const related = e.relatedTarget as globalThis.Node | null;
+                                    if (related && e.currentTarget.contains(related)) return;
+                                    if (dragOverTarget === 'ungrouped') setDragOverTarget(null);
+                                }}
+                                onDrop={(e) => {
+                                    e.preventDefault();
+                                    const id = e.dataTransfer.getData('application/x-spatialtasks-project');
+                                    if (id) moveProjectToFolder(id, null);
+                                    setDragOverTarget(null);
+                                    setDraggingProjectId(null);
+                                }}
+                            >
+                                {ungroupedProjects.map(project => renderProjectRow(project))}
+                                {folders.length > 0 && ungroupedProjects.length === 0 && (
+                                    <div className="px-3 py-1.5 text-[11px] text-gray-600 italic select-none">
+                                        Drop here to ungroup
+                                    </div>
+                                )}
+                            </div>
+
+                            {/* Folder sections */}
+                            {sortedFolders.map(folder => {
+                                const folderProjects = projectsByFolder.get(folder.id) ?? [];
+                                const isDragOver = dragOverTarget === folder.id;
+                                return (
+                                    <div key={folder.id} className="mt-1">
+                                        <div
                                             className={clsx(
-                                                "w-full text-left px-3 py-2 rounded-md text-sm transition-colors",
-                                                activeProjectId === project.id
-                                                    ? "bg-purple-900/30 text-purple-300 border border-purple-800"
-                                                    : "text-gray-400 hover:bg-gray-800 hover:text-gray-200"
+                                                "group flex items-center rounded-md transition-colors",
+                                                isDragOver && "ring-1 ring-purple-500 bg-purple-900/10"
                                             )}
+                                            onDragOver={(e) => {
+                                                if (!draggingProjectId) return;
+                                                e.preventDefault();
+                                                e.dataTransfer.dropEffect = 'move';
+                                                if (dragOverTarget !== folder.id) setDragOverTarget(folder.id);
+                                            }}
+                                            onDragLeave={(e) => {
+                                                const related = e.relatedTarget as globalThis.Node | null;
+                                                if (related && e.currentTarget.contains(related)) return;
+                                                if (dragOverTarget === folder.id) setDragOverTarget(null);
+                                            }}
+                                            onDrop={(e) => {
+                                                e.preventDefault();
+                                                const id = e.dataTransfer.getData('application/x-spatialtasks-project');
+                                                if (id) moveProjectToFolder(id, folder.id);
+                                                setDragOverTarget(null);
+                                                setDraggingProjectId(null);
+                                            }}
                                         >
-                                            {project.title}
-                                        </button>
-                                    )}
-                                    {projects.length > 1 && editingProjectId !== project.id && (
-                                        <button
-                                            onClick={(e) => { e.stopPropagation(); setDeleteConfirmId(project.id); }}
-                                            className="absolute right-1 p-1 rounded text-gray-600 opacity-0 group-hover:opacity-100 touch:opacity-70 hover:text-red-400 hover:bg-gray-800 transition-all touch:min-h-[44px] touch:min-w-[44px] touch:flex touch:items-center touch:justify-center"
-                                            title="Delete project"
-                                        >
-                                            <Trash2 className="w-3.5 h-3.5" />
-                                        </button>
-                                    )}
-                                </div>
-                            ))}
+                                            <button
+                                                onClick={() => toggleFolderCollapsed(folder.id)}
+                                                className="p-1 text-gray-500 hover:text-gray-300 touch:min-h-[44px] touch:min-w-[44px] touch:flex touch:items-center touch:justify-center"
+                                                title={folder.collapsed ? 'Expand folder' : 'Collapse folder'}
+                                            >
+                                                {folder.collapsed
+                                                    ? <ChevronRight className="w-3.5 h-3.5" />
+                                                    : <ChevronDown className="w-3.5 h-3.5" />}
+                                            </button>
+                                            {editingFolderId === folder.id ? (
+                                                <input
+                                                    autoFocus
+                                                    value={editingFolderTitle}
+                                                    onChange={(e) => setEditingFolderTitle(e.target.value)}
+                                                    onBlur={() => {
+                                                        const trimmed = editingFolderTitle.trim();
+                                                        if (trimmed && trimmed !== folder.title) {
+                                                            renameFolder(folder.id, trimmed);
+                                                        }
+                                                        setEditingFolderId(null);
+                                                    }}
+                                                    onKeyDown={(e) => {
+                                                        if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+                                                        if (e.key === 'Escape') setEditingFolderId(null);
+                                                    }}
+                                                    className="flex-1 px-2 py-1 rounded text-xs font-semibold uppercase tracking-wider bg-gray-800 border border-purple-600 text-white focus:outline-none"
+                                                />
+                                            ) : (
+                                                <button
+                                                    onClick={() => toggleFolderCollapsed(folder.id)}
+                                                    onDoubleClick={() => { setEditingFolderId(folder.id); setEditingFolderTitle(folder.title); }}
+                                                    className="flex-1 text-left px-1 py-1 text-xs font-semibold uppercase tracking-wider text-gray-400 hover:text-gray-200 truncate"
+                                                    title={folder.title}
+                                                >
+                                                    {folder.title}
+                                                </button>
+                                            )}
+                                            {editingFolderId !== folder.id && (
+                                                <>
+                                                    <button
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
+                                                            setIsCreating(true);
+                                                            setCreatingInFolderId(folder.id);
+                                                            setIsCreatingFolder(false);
+                                                            // Ensure folder is expanded so the user sees the form
+                                                            if (folder.collapsed) toggleFolderCollapsed(folder.id);
+                                                        }}
+                                                        className="p-1 rounded text-gray-600 opacity-0 group-hover:opacity-100 touch:opacity-70 hover:text-purple-300 hover:bg-gray-800 transition-all touch:min-h-[44px] touch:min-w-[44px] touch:flex touch:items-center touch:justify-center"
+                                                        title="New project in folder"
+                                                    >
+                                                        <Plus className="w-3.5 h-3.5" />
+                                                    </button>
+                                                    <button
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
+                                                            if (folderProjects.length === 0) {
+                                                                setEmptyFolderDeleteId(folder.id);
+                                                            } else {
+                                                                setFolderDeleteId(folder.id);
+                                                            }
+                                                        }}
+                                                        className="p-1 mr-1 rounded text-gray-600 opacity-0 group-hover:opacity-100 touch:opacity-70 hover:text-red-400 hover:bg-gray-800 transition-all touch:min-h-[44px] touch:min-w-[44px] touch:flex touch:items-center touch:justify-center"
+                                                        title="Delete folder"
+                                                    >
+                                                        <Trash2 className="w-3.5 h-3.5" />
+                                                    </button>
+                                                </>
+                                            )}
+                                        </div>
+                                        {!folder.collapsed && (
+                                            <div className="pl-4 mt-0.5 space-y-1 border-l border-gray-800 ml-3">
+                                                {isCreating && creatingInFolderId === folder.id && (
+                                                    <form
+                                                        onSubmit={(e) => {
+                                                            e.preventDefault();
+                                                            const title = newProjectTitle.trim() || 'Untitled Project';
+                                                            createProject(title, folder.id);
+                                                            setNewProjectTitle('');
+                                                            setIsCreating(false);
+                                                            setCreatingInFolderId(null);
+                                                            addToast(`Created "${title}"`, 'success');
+                                                        }}
+                                                    >
+                                                        <input
+                                                            autoFocus
+                                                            value={newProjectTitle}
+                                                            onChange={(e) => setNewProjectTitle(e.target.value)}
+                                                            onBlur={() => {
+                                                                if (!newProjectTitle.trim()) {
+                                                                    setIsCreating(false);
+                                                                    setCreatingInFolderId(null);
+                                                                }
+                                                            }}
+                                                            onKeyDown={(e) => {
+                                                                if (e.key === 'Escape') {
+                                                                    setNewProjectTitle('');
+                                                                    setIsCreating(false);
+                                                                    setCreatingInFolderId(null);
+                                                                }
+                                                            }}
+                                                            placeholder="Project name..."
+                                                            className="w-full px-3 py-2 rounded-md text-sm bg-gray-800 border border-purple-600 text-white placeholder-gray-500 focus:outline-none focus:border-purple-400"
+                                                        />
+                                                    </form>
+                                                )}
+                                                {folderProjects.map(project => renderProjectRow(project))}
+                                                {folderProjects.length === 0 && !(isCreating && creatingInFolderId === folder.id) && (
+                                                    <div className="px-3 py-1.5 text-[11px] text-gray-600 italic select-none">
+                                                        No projects — drop one here
+                                                    </div>
+                                                )}
+                                            </div>
+                                        )}
+                                    </div>
+                                );
+                            })}
                         </div>
                     </div>
 
@@ -431,6 +725,183 @@ export const Sidebar: React.FC<SidebarProps> = ({ onGenerateFlow, onImportPlan, 
         />
     ) : null;
 
+    const folderForDelete = folderDeleteId ? folders.find(f => f.id === folderDeleteId) : null;
+    const projectsInDeletingFolder = folderForDelete
+        ? projects.filter(p => p.folderId === folderForDelete.id)
+        : [];
+    const folderDeleteModal = folderForDelete ? (
+        <FolderDeleteModal
+            folderTitle={folderForDelete.title}
+            projectCount={projectsInDeletingFolder.length}
+            onKeepProjects={() => {
+                deleteFolder(folderForDelete.id, { deleteProjects: false });
+                addToast(`Deleted folder "${folderForDelete.title}"`, 'info');
+                setFolderDeleteId(null);
+            }}
+            onDeleteProjects={() => {
+                const ok = deleteFolder(folderForDelete.id, { deleteProjects: true });
+                if (ok) {
+                    addToast(`Deleted folder "${folderForDelete.title}" and its projects`, 'info');
+                } else {
+                    addToast(`Can't delete — workspace must keep at least one project`, 'error');
+                }
+                setFolderDeleteId(null);
+            }}
+            onCancel={() => setFolderDeleteId(null)}
+        />
+    ) : null;
+
+    const emptyFolderForDelete = emptyFolderDeleteId ? folders.find(f => f.id === emptyFolderDeleteId) : null;
+    const emptyFolderDeleteModal = emptyFolderForDelete ? (
+        <ConfirmModal
+            title="Delete Folder"
+            message={`Delete empty folder "${emptyFolderForDelete.title}"?`}
+            confirmLabel="Delete Folder"
+            danger
+            onConfirm={() => {
+                deleteFolder(emptyFolderForDelete.id, { deleteProjects: false });
+                addToast(`Deleted folder "${emptyFolderForDelete.title}"`, 'info');
+                setEmptyFolderDeleteId(null);
+            }}
+            onCancel={() => setEmptyFolderDeleteId(null)}
+        />
+    ) : null;
+
+    const mobileActionProject = mobileActionProjectId
+        ? projects.find(p => p.id === mobileActionProjectId)
+        : null;
+    const mobileActionSheet = mobileActionProject ? (
+        <div
+            className="fixed inset-0 z-[100] flex items-end justify-center"
+            onClick={() => setMobileActionProjectId(null)}
+        >
+            <div className="absolute inset-0 bg-black/60" />
+            <div
+                className="relative bg-slate-800 border-t border-slate-700 rounded-t-xl shadow-2xl w-full p-4 space-y-2"
+                onClick={e => e.stopPropagation()}
+            >
+                <div className="text-xs uppercase tracking-wider text-slate-500 text-center mb-2 truncate px-2">
+                    {mobileActionProject.title}
+                </div>
+                <button
+                    onClick={() => {
+                        setEditingProjectId(mobileActionProject.id);
+                        setEditingProjectTitle(mobileActionProject.title);
+                        setMobileActionProjectId(null);
+                    }}
+                    className="w-full px-4 py-3 rounded-lg text-sm font-medium bg-slate-700 hover:bg-slate-600 text-slate-100 transition-colors text-left"
+                >
+                    Rename
+                </button>
+                <button
+                    onClick={() => {
+                        setMoveSheetProjectId(mobileActionProject.id);
+                        setMobileActionProjectId(null);
+                    }}
+                    className="w-full px-4 py-3 rounded-lg text-sm font-medium bg-slate-700 hover:bg-slate-600 text-slate-100 transition-colors text-left"
+                >
+                    Move to folder…
+                </button>
+                {projects.length > 1 && (
+                    <button
+                        onClick={() => {
+                            setDeleteConfirmId(mobileActionProject.id);
+                            setMobileActionProjectId(null);
+                        }}
+                        className="w-full px-4 py-3 rounded-lg text-sm font-medium bg-red-600/20 text-red-300 hover:bg-red-600/30 transition-colors text-left"
+                    >
+                        Delete
+                    </button>
+                )}
+                <button
+                    onClick={() => setMobileActionProjectId(null)}
+                    className="w-full px-4 py-3 rounded-lg text-sm font-medium text-slate-400 bg-slate-900 hover:bg-slate-700 transition-colors"
+                >
+                    Cancel
+                </button>
+            </div>
+        </div>
+    ) : null;
+
+    const moveSheetProject = moveSheetProjectId
+        ? projects.find(p => p.id === moveSheetProjectId)
+        : null;
+    const moveSheet = moveSheetProject ? (
+        <div
+            className="fixed inset-0 z-[100] flex items-end justify-center"
+            onClick={() => setMoveSheetProjectId(null)}
+        >
+            <div className="absolute inset-0 bg-black/60" />
+            <div
+                className="relative bg-slate-800 border-t border-slate-700 rounded-t-xl shadow-2xl w-full p-4 max-h-[70vh] overflow-y-auto space-y-2"
+                onClick={e => e.stopPropagation()}
+            >
+                <div className="text-xs uppercase tracking-wider text-slate-500 text-center mb-2">
+                    Move &ldquo;{moveSheetProject.title}&rdquo; to…
+                </div>
+                <button
+                    onClick={() => {
+                        moveProjectToFolder(moveSheetProject.id, null);
+                        setMoveSheetProjectId(null);
+                        addToast('Moved to Ungrouped', 'success');
+                    }}
+                    disabled={!moveSheetProject.folderId}
+                    className={clsx(
+                        "w-full px-4 py-3 rounded-lg text-sm font-medium transition-colors text-left",
+                        !moveSheetProject.folderId
+                            ? "bg-slate-900 text-slate-500 cursor-default"
+                            : "bg-slate-700 hover:bg-slate-600 text-slate-100"
+                    )}
+                >
+                    Ungrouped {!moveSheetProject.folderId && '(current)'}
+                </button>
+                {sortedFolders.map(folder => {
+                    const isCurrent = moveSheetProject.folderId === folder.id;
+                    return (
+                        <button
+                            key={folder.id}
+                            onClick={() => {
+                                moveProjectToFolder(moveSheetProject.id, folder.id);
+                                setMoveSheetProjectId(null);
+                                addToast(`Moved to "${folder.title}"`, 'success');
+                            }}
+                            disabled={isCurrent}
+                            className={clsx(
+                                "w-full px-4 py-3 rounded-lg text-sm font-medium transition-colors text-left",
+                                isCurrent
+                                    ? "bg-slate-900 text-slate-500 cursor-default"
+                                    : "bg-slate-700 hover:bg-slate-600 text-slate-100"
+                            )}
+                        >
+                            {folder.title} {isCurrent && '(current)'}
+                        </button>
+                    );
+                })}
+                <button
+                    onClick={() => {
+                        const title = window.prompt('New folder name');
+                        const trimmed = (title ?? '').trim();
+                        if (!trimmed) return;
+                        const id = createFolder(trimmed);
+                        moveProjectToFolder(moveSheetProject.id, id);
+                        setMoveSheetProjectId(null);
+                        addToast(`Created folder "${trimmed}"`, 'success');
+                    }}
+                    className="w-full px-4 py-3 rounded-lg text-sm font-medium bg-purple-600/20 text-purple-300 hover:bg-purple-600/30 transition-colors text-left flex items-center gap-2"
+                >
+                    <FolderPlus className="w-4 h-4" />
+                    New folder…
+                </button>
+                <button
+                    onClick={() => setMoveSheetProjectId(null)}
+                    className="w-full px-4 py-3 rounded-lg text-sm font-medium text-slate-400 bg-slate-900 hover:bg-slate-700 transition-colors"
+                >
+                    Cancel
+                </button>
+            </div>
+        </div>
+    ) : null;
+
     if (isMobile) {
         return (
             <>
@@ -447,6 +918,10 @@ export const Sidebar: React.FC<SidebarProps> = ({ onGenerateFlow, onImportPlan, 
                 </div>
                 {resetConfirmModal}
                 {deleteConfirmModal}
+                {folderDeleteModal}
+                {emptyFolderDeleteModal}
+                {mobileActionSheet}
+                {moveSheet}
             </>
         );
     }
@@ -456,6 +931,8 @@ export const Sidebar: React.FC<SidebarProps> = ({ onGenerateFlow, onImportPlan, 
             {sidebarContent}
             {resetConfirmModal}
             {deleteConfirmModal}
+            {folderDeleteModal}
+            {emptyFolderDeleteModal}
         </>
     );
 };

--- a/src/components/UI/FolderDeleteModal.tsx
+++ b/src/components/UI/FolderDeleteModal.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useRef } from 'react';
+
+interface FolderDeleteModalProps {
+    folderTitle: string;
+    projectCount: number;
+    onKeepProjects: () => void;
+    onDeleteProjects: () => void;
+    onCancel: () => void;
+}
+
+export const FolderDeleteModal: React.FC<FolderDeleteModalProps> = ({
+    folderTitle,
+    projectCount,
+    onKeepProjects,
+    onDeleteProjects,
+    onCancel,
+}) => {
+    const keepRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        const handleEscape = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onCancel();
+        };
+        document.addEventListener('keydown', handleEscape);
+        keepRef.current?.focus();
+        return () => document.removeEventListener('keydown', handleEscape);
+    }, [onCancel]);
+
+    const plural = projectCount === 1 ? 'project' : 'projects';
+
+    return (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center" onClick={onCancel}>
+            <div className="absolute inset-0 bg-black/60" />
+
+            <div
+                className="relative bg-slate-800 border border-slate-700 rounded-xl shadow-2xl max-w-sm w-[calc(100%-2rem)] mx-4 p-6"
+                onClick={e => e.stopPropagation()}
+            >
+                <h3 className="text-white font-semibold text-lg mb-2">Delete Folder</h3>
+                <p className="text-slate-300 text-sm mb-6">
+                    Delete folder &ldquo;{folderTitle}&rdquo;? It contains {projectCount} {plural}.
+                </p>
+
+                <div className="flex flex-col gap-2">
+                    <button
+                        ref={keepRef}
+                        onClick={onKeepProjects}
+                        className="px-4 py-2.5 touch:py-3 rounded-lg text-sm font-medium bg-purple-600 hover:bg-purple-500 text-white transition-colors"
+                    >
+                        Keep projects (move to root)
+                    </button>
+                    <button
+                        onClick={onDeleteProjects}
+                        className="px-4 py-2.5 touch:py-3 rounded-lg text-sm font-medium bg-red-600 hover:bg-red-500 text-white transition-colors"
+                    >
+                        Delete projects too
+                    </button>
+                    <button
+                        onClick={onCancel}
+                        className="px-4 py-2.5 touch:py-3 rounded-lg text-sm font-medium text-slate-300 bg-slate-700 hover:bg-slate-600 transition-colors"
+                    >
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { temporal } from 'zundo';
 import { v4 as uuidv4 } from 'uuid';
-import { Workspace, Node, Graph, Edge, Project, WorkspaceSettings, AccentColor } from '../types';
+import { Workspace, Node, Graph, Edge, Project, Folder, WorkspaceSettings, AccentColor } from '../types';
 import type { LayoutStrategy } from '../layout/layoutTypes';
 import { generateWorkspace } from '../utils/generator';
 import { saveGeminiConfig, loadGeminiConfig } from '../lib/workspaceSync';
@@ -66,9 +66,16 @@ interface WorkspaceState extends Workspace {
     clearCanvasAction: () => void;
 
     // Project management
-    createProject: (title: string) => void;
+    createProject: (title: string, folderId?: string) => void;
     renameProject: (projectId: string, title: string) => void;
     deleteProject: (projectId: string) => void;
+
+    // Folder management
+    createFolder: (title: string) => string;
+    renameFolder: (folderId: string, title: string) => void;
+    deleteFolder: (folderId: string, opts: { deleteProjects: boolean }) => boolean;
+    toggleFolderCollapsed: (folderId: string) => void;
+    moveProjectToFolder: (projectId: string, folderId: string | null) => void;
 
     // Graph edits
     addNode: (node: Node) => void;
@@ -238,11 +245,14 @@ export const useWorkspaceStore = create<WorkspaceState>()(
                 });
             },
 
-            createProject: (title) => {
-                const { projects, graphs } = get();
+            createProject: (title, folderId) => {
+                const { projects, graphs, folders } = get();
                 const projectId = uuidv4();
                 const rootGraphId = uuidv4();
                 const now = new Date().toISOString();
+
+                // Only attach folderId if it references an existing folder
+                const validFolderId = folderId && folders.some(f => f.id === folderId) ? folderId : undefined;
 
                 const newProject: Project = {
                     id: projectId,
@@ -250,6 +260,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
                     rootGraphId,
                     createdAt: now,
                     updatedAt: now,
+                    folderId: validFolderId,
                 };
 
                 const rootGraph: Graph = {
@@ -319,6 +330,120 @@ export const useWorkspaceStore = create<WorkspaceState>()(
                 }
 
                 set(updates);
+            },
+
+            createFolder: (title) => {
+                const { folders } = get();
+                const id = uuidv4();
+                const now = new Date().toISOString();
+                const newFolder: Folder = {
+                    id,
+                    title: title.trim() || 'Untitled Folder',
+                    collapsed: false,
+                    order: folders.length,
+                    createdAt: now,
+                    updatedAt: now,
+                };
+                set({ folders: [...folders, newFolder] });
+                return id;
+            },
+
+            renameFolder: (folderId, title) => {
+                const trimmed = title.trim();
+                if (!trimmed) return;
+                const { folders } = get();
+                set({
+                    folders: folders.map(f =>
+                        f.id === folderId ? { ...f, title: trimmed, updatedAt: new Date().toISOString() } : f
+                    ),
+                });
+            },
+
+            toggleFolderCollapsed: (folderId) => {
+                const { folders } = get();
+                set({
+                    folders: folders.map(f =>
+                        f.id === folderId ? { ...f, collapsed: !f.collapsed } : f
+                    ),
+                });
+            },
+
+            moveProjectToFolder: (projectId, folderId) => {
+                const { projects, folders } = get();
+                const project = projects.find(p => p.id === projectId);
+                if (!project) return;
+                const targetFolderId = folderId && folders.some(f => f.id === folderId) ? folderId : undefined;
+                if ((project.folderId ?? undefined) === targetFolderId) return;
+                set({
+                    projects: projects.map(p =>
+                        p.id === projectId
+                            ? { ...p, folderId: targetFolderId, updatedAt: new Date().toISOString() }
+                            : p
+                    ),
+                });
+            },
+
+            deleteFolder: (folderId, { deleteProjects }) => {
+                const { projects, folders, graphs, activeProjectId } = get();
+                const folder = folders.find(f => f.id === folderId);
+                if (!folder) return false;
+
+                const projectsInFolder = projects.filter(p => p.folderId === folderId);
+
+                if (!deleteProjects) {
+                    // Move inner projects to root, then remove folder
+                    set({
+                        projects: projects.map(p =>
+                            p.folderId === folderId
+                                ? { ...p, folderId: undefined, updatedAt: new Date().toISOString() }
+                                : p
+                        ),
+                        folders: folders.filter(f => f.id !== folderId),
+                    });
+                    return true;
+                }
+
+                // Deleting projects too — guard against emptying the workspace
+                if (projects.length - projectsInFolder.length < 1) {
+                    return false;
+                }
+
+                // Collect all descendant graph IDs for every project we're about to delete
+                const graphIdsToDelete: string[] = [];
+                const collect = (graphId: string) => {
+                    const g = graphs[graphId];
+                    if (!g) return;
+                    graphIdsToDelete.push(graphId);
+                    g.nodes.forEach(n => {
+                        if (n.childGraphId) collect(n.childGraphId);
+                    });
+                };
+                projectsInFolder.forEach(p => collect(p.rootGraphId));
+
+                const updatedGraphs = { ...graphs };
+                graphIdsToDelete.forEach(id => delete updatedGraphs[id]);
+
+                const deletedIds = new Set(projectsInFolder.map(p => p.id));
+                const updatedProjects = projects.filter(p => !deletedIds.has(p.id));
+                const updatedFolders = folders.filter(f => f.id !== folderId);
+
+                const updates: Partial<WorkspaceState> = {
+                    projects: updatedProjects,
+                    folders: updatedFolders,
+                    graphs: updatedGraphs,
+                };
+
+                if (activeProjectId && deletedIds.has(activeProjectId)) {
+                    const next = updatedProjects[0];
+                    const nextRoot = updatedGraphs[next.rootGraphId];
+                    updates.activeProjectId = next.id;
+                    updates.activeGraphId = next.rootGraphId;
+                    updates.navStack = [{ graphId: nextRoot.id, label: nextRoot.title }];
+                    updates.executionMode = false;
+                }
+
+                set(updates);
+                return true;
             },
 
             addNode: (node) => {
@@ -587,6 +712,11 @@ export const useWorkspaceStore = create<WorkspaceState>()(
                         if (!p.id || !p.title || !p.rootGraphId) throw new Error('Invalid project');
                     }
 
+                    // Folders are optional for backward compatibility
+                    if (data.folders !== undefined && !Array.isArray(data.folders)) {
+                        throw new Error('Invalid folders');
+                    }
+
                     // Validate graph/node/edge shape
                     for (const [gid, g] of Object.entries(data.graphs)) {
                         const graph = g as any;
@@ -607,6 +737,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
 
                     // Sanitize: strip any prototype pollution
                     const clean = JSON.parse(JSON.stringify(data));
+                    // Default folders to [] for pre-v2 imports
+                    if (!Array.isArray(clean.folders)) clean.folders = [];
                     set(clean);
                 } catch (e) {
                     console.error("Failed to import", e);
@@ -618,6 +750,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
                 const geminiConfig = loadGeminiConfig();
                 set({
                     ...data,
+                    folders: Array.isArray(data.folders) ? data.folders : [],
                     settings: {
                         ...data.settings,
                         geminiApiKey: geminiConfig.geminiApiKey,
@@ -635,7 +768,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             partialize: (state) => {
                 const { _hydrated, _supabaseLoaded, ...rest } = state;
                 // Only track data fields for undo/redo, not transient flags
-                return { graphs: rest.graphs, projects: rest.projects } as WorkspaceState;
+                return { graphs: rest.graphs, projects: rest.projects, folders: rest.folders } as WorkspaceState;
             },
             limit: 50,
         }
@@ -643,6 +776,21 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         {
             name: STORAGE_KEY,
             storage: createJSONStorage(() => localStorage),
+            version: 2,
+            migrate: (persistedState: any, fromVersion: number) => {
+                if (!persistedState || typeof persistedState !== 'object') return persistedState;
+                if (fromVersion < 2) {
+                    return {
+                        ...persistedState,
+                        version: 2,
+                        folders: Array.isArray(persistedState.folders) ? persistedState.folders : [],
+                        projects: Array.isArray(persistedState.projects)
+                            ? persistedState.projects.map((p: any) => ({ ...p, folderId: p.folderId ?? undefined }))
+                            : [],
+                    };
+                }
+                return persistedState;
+            },
             partialize: (state) => {
                 // Exclude transient flags and actions from localStorage
                 const { _hydrated, _supabaseLoaded, selectMode, _hasSelection, connectMode, autoEditNodeId, sidebarOpen, viewMode, focusNodeId, focusContextGraphId, syncStatus, syncError, lastSavedAt, pendingCanvasAction, ...rest } = state;
@@ -650,7 +798,13 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             },
             onRehydrateStorage: () => {
                 return (state) => {
-                    if (state) state._hydrated = true;
+                    if (state) {
+                        state._hydrated = true;
+                        // Safety net: if rehydration produced a workspace without folders (older save), heal it.
+                        if (!Array.isArray(state.folders)) {
+                            state.folders = [];
+                        }
+                    }
                 };
             },
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,6 +76,16 @@ export interface Project {
     rootGraphId: string;
     createdAt: string;
     updatedAt: string;
+    folderId?: string;
+}
+
+export interface Folder {
+    id: string;
+    title: string;
+    collapsed: boolean;
+    order: number;
+    createdAt: string;
+    updatedAt: string;
 }
 
 export type GeminiConnectionStatus = 'no_key' | 'configured' | 'error';
@@ -115,6 +125,7 @@ export interface WorkspaceSettings {
 export interface Workspace {
     version: number;
     projects: Project[];
+    folders: Folder[];
     activeProjectId: string | null;
     activeGraphId: string | null;
     // Navigation stack: array of { graphId, title } or just graphIds to build breadcrumbs

--- a/src/utils/generator.ts
+++ b/src/utils/generator.ts
@@ -283,8 +283,9 @@ export function generateWorkspace(seed: string = '42'): Workspace {
     const activeGraphId = p1Root;
 
     return {
-        version: 1,
+        version: 2,
         projects,
+        folders: [],
         graphs: ctx.graphs,
         activeProjectId,
         activeGraphId,


### PR DESCRIPTION
Introduces a flat (one-level) folder concept so users can group related
projects (e.g. a "Music" folder) in the sidebar. Folders are a
sidebar-only organizational affordance and do not affect the in-project
navStack.

Features:
- Folder CRUD (create/rename/delete) with collapse/expand state
  persisted to localStorage and synced via Supabase.
- HTML5 drag-and-drop on desktop: drag any project row onto a folder
  header or the "Ungrouped" section to reassign it.
- Mobile fallback: per-project action sheet with "Move to folder…"
  listing existing folders plus a "New folder…" shortcut.
- Three-button delete modal for non-empty folders (Cancel / Keep
  projects / Delete projects too); empty folders use the standard
  single-confirm modal. Cascading delete is blocked when it would
  empty the workspace.
- Workspace schema bumped to v2 with a migrate() hook so legacy v1
  localStorage blobs self-heal; hydrateFromSupabase and jsonImport
  normalize missing folders arrays.
- Zundo partialize extended to track folders so folder mutations are
  undoable alongside projects and graphs.

QA docs updated: new Flow 13b section in SPATIAL_TASKS_QA_GUIDE.md
with 12 new test cases (QA-C022 – QA-C033) and inventory additions
to QA_INVENTORY.md covering the new Folder entity, mutations, and
component.